### PR TITLE
Remove cloned buffers from parse errors

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,6 @@
 
 - The recent change from <code>ReaderParser</code> to <code>Parser</code> seems to have slowed the parsing. Investigate and fix.
 - Reconsider the order of calls in <code>parse_semi_quiet</code> so that simple types are tried first.
-- Remove <code>debug_bytes</code> from error handling as it slows down parsing. Instead, only use it for the error message.
 - Given the recent change into a single read, replace cloning with references.
 - Cache created filters.
 
@@ -45,6 +44,7 @@
 
 ## Refactor
 
+- Use <code>num_traits</code> to refactor the <code>num</code> module
 - Replace <code>println!</code> and <code>eprintln!</code> with <code>log</code> calls.
 - Consider converting the different instances of the <code>escape</code> methods into implementations of a trait <code>Escape</code>.
 - Remove <code>::std::str::from_utf8</code> especially in the context of converting <code>&[Byte]</code> to numeric types.
@@ -52,10 +52,13 @@
 
 ### Error Handling
 
-- Reconsider <code>Failure</code>s and <code>Warn</code>s. Fail as soon as possible, and only warn when further processing is possible.
-- Consider adopting <code>nom</code> errors to be able to use <code>nom</code> combinators alongside the <code>Parser</code> trait.
-- Some <code>String</code> in errors can be changed to <code>&'static str</code>.
-- Standardise tests.
+- Combine parse and process error codes.
+- Reconsider <code>Failure</code>s and <code>Recoverable</code>s. Fail as soon as possible, and only warn when further processing is possible.
+- [O] Standardise tests.
+    - [X] Pdf errors.
+    - [X] Parse errors.
+    - [ ] Process errors.
+    - [ ] Other sporadic errors.
 
 ## Future Work
 

--- a/bin/main.rs
+++ b/bin/main.rs
@@ -30,13 +30,13 @@ fn main() {
             Ok(pdf) => pdf,
             Err(err) => {
                 // TODO Replace with log::error!.
-                eprintln!("ERROR: Failed to build PDF: {:?}", err);
+                eprintln!("ERROR: Failed to build PDF: {}", err);
                 continue;
             }
         };
         if let Err(err) = pdf.status() {
             // TODO Replace with log::error!.
-            eprintln!("ERROR: PDF status: {:#?}", err);
+            eprintln!("ERROR: PDF status: {}", err);
             continue;
         }
         // TODO Replace with log::info!.

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -5,13 +5,11 @@ use crate::Byte;
 // This slows down the program. Apply it only for display purposes.
 pub(crate) fn debug_bytes(bytes: &[Byte]) -> String {
     // FIXME Reconsider the length of the debug output
-    let len = 105.min(bytes.len());
-    let bytes = &bytes[..len];
     let mut result = String::new();
     for &byte in bytes {
         if byte.is_ascii_graphic() || is_white_space(byte) {
             // Preserve ASCII printable and white-space characters
-            result.push(byte as char);
+            result.push(char::from(byte));
         } else {
             // Hexadecimal representation of other bytes
             result.push_str(&format!("\\x{:02X}", byte));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,10 @@ const DECODED_LIMIT: usize = 1 << 30;
 
 /// Although u32 would suffice for most cases, allowing for ~.5 GiB files,
 /// [7.5.4 Cross-reference table, p56] only restricts bytes offsets to 10
-/// digits, allowing for ~9.3 GiB files. Hence, it can be represented as a u64.
-type Offset = u64;
+/// digits, allowing for ~9.3 GiB files. Hence, it can be represented as a u64
+/// if the operating system supports it. However, in any case, we need to
+/// convert to `usize` to index the buffer.
+type Offset = usize;
 /// REFERENCE: [3.33 indirect object, p10]
 /// - Object numbers are positive integer objects.
 /// - The object number cannot exceed allowed offsets.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,16 +2,16 @@
 #![allow(dead_code)]
 
 mod convert;
-pub mod file;
 mod fmt;
 mod object;
 mod parse;
+pub mod pdf;
 mod process;
 mod xref;
 
 use ::std::num::NonZeroU64;
 
-pub use self::file::PdfBuilder;
+pub use self::pdf::PdfBuilder;
 
 // Limit the size of the decoded stream to 1 GiB.
 const DECODED_LIMIT: usize = 1 << 30;

--- a/src/object/direct/array.rs
+++ b/src/object/direct/array.rs
@@ -14,7 +14,6 @@ use crate::fmt::debug_bytes;
 use crate::object::direct::DirectValue;
 use crate::parse::character_set::white_space_or_comment;
 use crate::parse::error::ParseErr;
-use crate::parse::error::ParseRecoverable;
 use crate::parse::error::ParseResult;
 use crate::parse::Parser;
 use crate::parse_error;

--- a/src/object/direct/array.rs
+++ b/src/object/direct/array.rs
@@ -8,15 +8,15 @@ use ::std::fmt::Formatter;
 use ::std::fmt::Result as FmtResult;
 use ::std::ops::Deref;
 
-use self::error::ArrayFailure;
-use self::error::ArrayRecoverable;
-use crate::fmt::debug_bytes;
 use crate::object::direct::DirectValue;
 use crate::parse::character_set::white_space_or_comment;
 use crate::parse::error::ParseErr;
+use crate::parse::error::ParseErrorCode;
+use crate::parse::error::ParseFailure;
+use crate::parse::error::ParseRecoverable;
 use crate::parse::error::ParseResult;
 use crate::parse::Parser;
-use crate::parse_error;
+use crate::parse_recoverable;
 use crate::Byte;
 
 /// REFERENCE: [7.3.6 Array objects, p29]
@@ -50,39 +50,40 @@ impl PartialEq for Array {
     }
 }
 
-impl Parser for Array {
+impl Parser<'_> for Array {
     fn parse(buffer: &[Byte]) -> ParseResult<(&[Byte], Self)> {
         let mut array = vec![];
         let mut value: DirectValue;
-        let (mut buffer, _) =
-            terminated(char('['), opt(white_space_or_comment))(buffer).map_err(parse_error!(
+        let (mut buffer, _) = terminated(char('['), opt(white_space_or_comment))(buffer).map_err(
+            parse_recoverable!(
                 e,
-                ArrayRecoverable::NotFound {
-                    code: e.code,
-                    input: debug_bytes(buffer)
+                ParseRecoverable {
+                    buffer: e.input,
+                    object: stringify!(Array),
+                    code: ParseErrorCode::NotFound(e.code)
                 }
-            ))?;
+            ),
+        )?;
         // Here, we know that the buffer starts with an array, and the following
         // errors should be propagated as ArrayFailure
         loop {
             // Check for the end of the array (closing square bracket)
-            if let Ok((remaining, _)) = char::<_, NomError<_>>(']')(buffer) {
-                buffer = remaining;
+            if let Ok((remains, _)) = char::<_, NomError<_>>(']')(buffer) {
+                buffer = remains;
                 break;
             }
             // Parse the value
-            (buffer, value) =
-                DirectValue::parse_semi_quiet::<DirectValue>(buffer).unwrap_or_else(|| {
-                    Err(ParseErr::Failure(
-                        ArrayFailure::MissingClosing(debug_bytes(buffer)).into(),
-                    ))
-                })?;
+            (buffer, value) = DirectValue::parse(buffer).map_err(|err| ParseFailure {
+                buffer: err.buffer(),
+                object: stringify!(Array),
+                code: ParseErrorCode::RecMissingClosing(Box::new(err.code())),
+            })?;
 
             array.push(value);
             // opt does not return an error, so there is no need for specific
             // error handling
-            if let Ok((remaining, _)) = opt(white_space_or_comment)(buffer) {
-                buffer = remaining;
+            if let Ok((remains, _)) = opt(white_space_or_comment)(buffer) {
+                buffer = remains;
             }
         }
 
@@ -124,24 +125,6 @@ mod convert {
     }
 }
 
-pub(crate) mod error {
-
-    use ::nom::error::ErrorKind;
-    use ::thiserror::Error;
-
-    #[derive(Debug, Error, PartialEq, Clone)]
-    pub enum ArrayRecoverable {
-        #[error("Not found: {code:?}. Input: {input}")]
-        NotFound { code: ErrorKind, input: String },
-    }
-
-    #[derive(Debug, Error, PartialEq, Clone)]
-    pub enum ArrayFailure {
-        #[error("Missing Closing: Expected a name or closing angle brackets. Input: {0}")]
-        MissingClosing(String),
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use ::nom::error::ErrorKind;
@@ -152,7 +135,6 @@ mod tests {
     use crate::object::direct::null::Null;
     use crate::object::direct::string::Hexadecimal;
     use crate::object::direct::string::Literal;
-    use crate::parse::error::ParseFailure;
     use crate::parse_assert_eq;
 
     #[test]
@@ -201,20 +183,20 @@ mod tests {
 
         // Array: Not found
         let parse_result = Array::parse(b"1 1.0 true null(A literal string)/Name");
-        let expected_error = ParseErr::Error(
-            ArrayRecoverable::NotFound {
-                code: ErrorKind::Char,
-                input: "1 1.0 true null(A literal string)/Name".to_string(),
-            }
-            .into(),
-        );
+        let expected_error = ParseRecoverable {
+            buffer: b"1 1.0 true null(A literal string)/Name",
+            object: stringify!(Array),
+            code: ParseErrorCode::NotFound(ErrorKind::Char),
+        };
         assert_err_eq!(parse_result, expected_error);
 
         // Array: Missing closing square bracket
         let parse_result = Array::parse(b"[1 1.0 true null(A literal string)/Name");
-        let expected_error = ParseErr::Failure(ParseFailure::Array(ArrayFailure::MissingClosing(
-            "".to_string(),
-        )));
+        let expected_error = ParseFailure {
+            buffer: b"",
+            object: stringify!(Array),
+            code: ParseErrorCode::RecMissingClosing(Box::new(ParseErrorCode::NotFoundUnion)),
+        };
         assert_err_eq!(parse_result, expected_error);
     }
 }

--- a/src/object/direct/boolean.rs
+++ b/src/object/direct/boolean.rs
@@ -10,7 +10,6 @@ use ::std::fmt::Result as FmtResult;
 use self::error::BooleanRecoverable;
 use crate::fmt::debug_bytes;
 use crate::parse::error::ParseErr;
-use crate::parse::error::ParseRecoverable;
 use crate::parse::error::ParseResult;
 use crate::parse::Parser;
 use crate::parse::KW_FALSE;

--- a/src/object/direct/boolean.rs
+++ b/src/object/direct/boolean.rs
@@ -7,14 +7,14 @@ use ::std::fmt::Display;
 use ::std::fmt::Formatter;
 use ::std::fmt::Result as FmtResult;
 
-use self::error::BooleanRecoverable;
-use crate::fmt::debug_bytes;
 use crate::parse::error::ParseErr;
+use crate::parse::error::ParseErrorCode;
+use crate::parse::error::ParseRecoverable;
 use crate::parse::error::ParseResult;
 use crate::parse::Parser;
 use crate::parse::KW_FALSE;
 use crate::parse::KW_TRUE;
-use crate::parse_error;
+use crate::parse_recoverable;
 use crate::Byte;
 
 /// REFERENCE:  [7.3.2 Boolean objects, p24]
@@ -27,32 +27,22 @@ impl Display for Boolean {
     }
 }
 
-impl Parser for Boolean {
+impl Parser<'_> for Boolean {
     fn parse(buffer: &[Byte]) -> ParseResult<(&[Byte], Self)> {
         let (buffer, value) = alt((
-            map(tag::<_, _, NomError<_>>(KW_TRUE), |_| Self(true)),
-            map(tag(KW_FALSE), |_| Self(false)),
+            map(tag::<_, _, NomError<_>>(KW_TRUE), |_true| Self(true)),
+            map(tag(KW_FALSE), |_false| Self(false)),
         ))(buffer)
-        .map_err(parse_error!(
+        .map_err(parse_recoverable!(
             e,
-            BooleanRecoverable::NotFound {
-                code: e.code,
-                input: debug_bytes(e.input),
+            ParseRecoverable {
+                buffer: e.input,
+                object: stringify!(Boolean),
+                code: ParseErrorCode::NotFound(e.code),
             }
         ))?;
 
         Ok((buffer, value))
-    }
-}
-
-pub(crate) mod error {
-    use ::nom::error::ErrorKind;
-    use ::thiserror::Error;
-
-    #[derive(Debug, Error, PartialEq, Clone)]
-    pub enum BooleanRecoverable {
-        #[error("Not found: {code:?}. Input: {input}")]
-        NotFound { code: ErrorKind, input: String },
     }
 }
 
@@ -103,13 +93,11 @@ mod tests {
     fn boolean_invalid() {
         // Boolean: Not found
         let parse_result = Boolean::parse(b"tr");
-        let expected_error = ParseErr::Error(
-            BooleanRecoverable::NotFound {
-                code: ErrorKind::Tag,
-                input: "tr".to_string(),
-            }
-            .into(),
-        );
+        let expected_error = ParseRecoverable {
+            buffer: b"tr",
+            object: stringify!(Boolean),
+            code: ParseErrorCode::NotFound(ErrorKind::Tag),
+        };
         assert_err_eq!(parse_result, expected_error);
     }
 }

--- a/src/object/direct/dictionary.rs
+++ b/src/object/direct/dictionary.rs
@@ -8,17 +8,17 @@ use ::std::fmt::Display;
 use ::std::fmt::Formatter;
 use ::std::fmt::Result as FmtResult;
 
-use self::error::DictionaryFailure;
-use self::error::DictionaryRecoverable;
 use super::name::Name;
 use super::DirectValue;
-use crate::fmt::debug_bytes;
 use crate::object::indirect::reference::Reference;
 use crate::parse::character_set::white_space_or_comment;
 use crate::parse::error::ParseErr;
+use crate::parse::error::ParseErrorCode;
+use crate::parse::error::ParseFailure;
+use crate::parse::error::ParseRecoverable;
 use crate::parse::error::ParseResult;
 use crate::parse::Parser;
-use crate::parse_error;
+use crate::parse_recoverable;
 use crate::Byte;
 
 /// REFERENCE: [7.3.7 Dictionary objects, p30-31]
@@ -44,56 +44,58 @@ impl PartialEq for Dictionary {
     }
 }
 
-impl Parser for Dictionary {
+impl Parser<'_> for Dictionary {
     fn parse(buffer: &[Byte]) -> ParseResult<(&[Byte], Self)> {
         let mut dictionary = HashMap::default();
         let mut key: Name;
         let mut value: DirectValue;
-        let (mut buffer, _) =
-            terminated(tag(b"<<"), opt(white_space_or_comment))(buffer).map_err(parse_error!(
+        let (mut buffer, _) = terminated(tag(b"<<"), opt(white_space_or_comment))(buffer).map_err(
+            parse_recoverable!(
                 e,
-                DictionaryRecoverable::NotFound {
-                    code: e.code,
-                    input: debug_bytes(buffer)
+                ParseRecoverable {
+                    buffer: e.input,
+                    object: stringify!(Dictionary),
+                    code: ParseErrorCode::NotFound(e.code),
                 }
-            ))?;
+            ),
+        )?;
         // Here, we know that the buffer starts with a dictionary, and the
         // following errors should be propagated as DictionaryFailure
         loop {
             // Check for the end of the dictionary (closing angle brackets)
-            if let Ok((remaining, _)) = tag::<_, _, NomError<_>>(b">>")(buffer) {
-                buffer = remaining;
+            if let Ok((remains, _)) = tag::<_, _, NomError<_>>(b">>")(buffer) {
+                buffer = remains;
                 break;
             }
             // Parse the key
-            (buffer, key) = Name::parse_semi_quiet::<Name>(buffer).unwrap_or_else(|| {
-                Err(ParseErr::Failure(
-                    DictionaryFailure::MissingClosing(debug_bytes(buffer)).into(),
-                ))
+            (buffer, key) = Name::parse(buffer).map_err(|err| ParseFailure {
+                buffer: err.buffer(),
+                object: stringify!(Dictionary),
+                code: ParseErrorCode::RecMissingClosing(Box::new(err.code())),
             })?;
             // opt does not return an error, so there is no need for specific
             // error handling
-            if let Ok((remaining, _)) = opt(white_space_or_comment)(buffer) {
-                buffer = remaining;
+            if let Ok((remains, _)) = opt(white_space_or_comment)(buffer) {
+                buffer = remains;
             }
             // Parse the value
-            (buffer, value) =
-                DirectValue::parse_semi_quiet::<DirectValue>(buffer).unwrap_or_else(|| {
-                    Err(ParseErr::Failure(
-                        DictionaryFailure::MissingValue {
-                            key: key.clone(),
-                            input: debug_bytes(buffer),
-                        }
-                        .into(),
-                    ))
-                })?;
+            (buffer, value) = DirectValue::parse(buffer).map_err(|err| ParseFailure {
+                buffer: err.buffer(),
+                object: stringify!(Dictionary),
+                code: ParseErrorCode::RecMissingValue(
+                    key.clone(), // TODO (TEMP) Consider refactoring to avoid cloning
+                    Box::new(err.code()),
+                ),
+            })?;
+
             // opt does not return an error, so there is no need for specific
             // error handling
-            if let Ok((remaining, _)) = opt(white_space_or_comment)(buffer) {
-                buffer = remaining;
+            if let Ok((remains, _)) = opt(white_space_or_comment)(buffer) {
+                buffer = remains;
             }
             // Record the key-value pair
             if let Some(old_value) = dictionary.insert(key.clone(), value.clone()) {
+                // TODO (TEMP) Consider refactoring to avoid cloning
                 // Dictionary keys should not be duplicated.
                 // REFERENCE: [7.3.7 Dictionary objects, p30]
                 //
@@ -181,10 +183,10 @@ mod convert {
             self.get(key)
                 .map(|value| {
                     value.as_array().ok_or_else(|| DataTypeError {
-                        key,
+                        entry: key,
                         expected_type: stringify!(u64),
                         value: value.to_string(),
-                        dictionary: self.to_string(),
+                        object: self.to_string(),
                     })
                 })
                 .transpose()
@@ -197,10 +199,10 @@ mod convert {
             self.get(key)
                 .map(|value| {
                     value.as_name().ok_or_else(|| DataTypeError {
-                        key,
+                        entry: key,
                         expected_type: stringify!(u64),
                         value: value.to_string(),
-                        dictionary: self.to_string(),
+                        object: self.to_string(),
                     })
                 })
                 .transpose()
@@ -217,10 +219,30 @@ mod convert {
                         .and_then(Numeric::as_integer)
                         .and_then(Integer::as_u64)
                         .ok_or_else(|| DataTypeError {
-                            key,
+                            entry: key,
                             expected_type: stringify!(u64),
                             value: value.to_string(),
-                            dictionary: self.to_string(),
+                            object: self.to_string(),
+                        })
+                })
+                .transpose()
+        }
+
+        pub(crate) fn get_usize<'key>(
+            &self,
+            key: &'key str,
+        ) -> StdResult<Option<usize>, DataTypeError<'key>> {
+            self.get(key)
+                .map(|value| {
+                    value
+                        .as_numeric()
+                        .and_then(Numeric::as_integer)
+                        .and_then(Integer::as_usize)
+                        .ok_or_else(|| DataTypeError {
+                            entry: key,
+                            expected_type: stringify!(usize),
+                            value: value.to_string(),
+                            object: self.to_string(),
                         })
                 })
                 .transpose()
@@ -233,10 +255,10 @@ mod convert {
             self.get(key)
                 .map(|value| {
                     value.as_reference().ok_or_else(|| DataTypeError {
-                        key,
+                        entry: key,
                         expected_type: stringify!(Reference),
                         value: value.to_string(),
-                        dictionary: self.to_string(),
+                        object: self.to_string(),
                     })
                 })
                 .transpose()
@@ -245,36 +267,18 @@ mod convert {
 }
 
 pub(crate) mod error {
-    use ::nom::error::ErrorKind;
     use ::thiserror::Error;
-
-    use crate::object::direct::name::Name;
-
-    #[derive(Debug, Error, PartialEq, Clone)]
-    pub enum DictionaryRecoverable {
-        #[error("Not found: {code:?}. Input: {input}")]
-        NotFound { code: ErrorKind, input: String },
-    }
-
-    #[derive(Debug, Error, PartialEq, Clone)]
-    pub enum DictionaryFailure {
-        #[error("Missing Value for key {key}. Input: {input}")]
-        MissingValue { key: Name, input: String },
-        #[error("Missing Closing: Expected a name or closing angle brackets. Input: {0}")]
-        MissingClosing(String),
-    }
 
     // TODO(TEMP) Replace the two errors below to DictionaryError
     #[derive(Debug, Error, PartialEq, Clone)]
     #[error(
-        "Wrong data type. Key {key}. Expected a {expected_type} value, found {value} in \
-         {dictionary}"
+        "Data type. entry {entry}. Expected a {expected_type} value, found {value} in {object}"
     )]
-    pub struct DataTypeError<'key> {
-        pub(crate) key: &'key str,
+    pub struct DataTypeError<'entry> {
+        pub(crate) entry: &'entry str,
         pub(crate) expected_type: &'static str,
-        pub(crate) value: String,      // TODO (TEMP)
-        pub(crate) dictionary: String, // TODO (TEMP)
+        pub(crate) value: String, // TODO (TEMP) Refactor to avoid changing the type to String
+        pub(crate) object: String, // TODO (TEMP) Refactor to avoid changing the type to String
     }
 
     #[derive(Debug, Error, PartialEq, Clone, Copy)]
@@ -292,7 +296,6 @@ mod tests {
     use super::*;
     use crate::assert_err_eq;
     use crate::object::direct::null::Null;
-    use crate::parse::error::ParseFailure;
 
     // TODO Add tests, e.g. the trailer dictionaries used in xref
     // #[test]
@@ -304,36 +307,48 @@ mod tests {
 
         // Dictionary: Not found
         let parsed_result = Dictionary::parse(b"/Type /Type1");
-        let expected_error = ParseErr::Error(
-            DictionaryRecoverable::NotFound {
-                code: ErrorKind::Tag,
-                input: "/Type /Type1".to_string(),
-            }
-            .into(),
-        );
+        let expected_error = ParseRecoverable {
+            buffer: b"/Type /Type1",
+            object: stringify!(Dictionary),
+            code: ParseErrorCode::NotFound(ErrorKind::Tag),
+        };
         assert_err_eq!(parsed_result, expected_error);
 
         // Dictionary: Single quotes
         let parsed_result = Dictionary::parse(b"<< /Type /Type1");
-        let expected_error = ParseErr::Failure(ParseFailure::Dictionary(
-            DictionaryFailure::MissingClosing("".to_string()),
-        ));
+        let expected_error = ParseFailure {
+            buffer: b"",
+            object: stringify!(Dictionary),
+            code: ParseErrorCode::RecMissingClosing(Box::new(ParseErrorCode::NotFound(
+                ErrorKind::Char,
+            ))),
+        };
         assert_err_eq!(parsed_result, expected_error);
 
         // Dictionary: Spaced quotes
         let parsed_result = Dictionary::parse(b"<< /Type /Type1 /Subtype << /Type /Type2> > >>");
-        let expected_error = ParseErr::Failure(ParseFailure::Dictionary(
-            DictionaryFailure::MissingClosing("> > >>".to_string()),
-        ));
+        let expected_error = ParseFailure {
+            buffer: b"> > >>",
+            object: stringify!(Dictionary),
+            code: ParseErrorCode::RecMissingValue(
+                Name::from("Subtype"),
+                Box::new(ParseErrorCode::RecMissingClosing(Box::new(
+                    ParseErrorCode::NotFound(ErrorKind::Char),
+                ))),
+            ),
+        };
         assert_err_eq!(parsed_result, expected_error);
 
         // Dictionary: Missing value
         let parsed_result = Dictionary::parse(b"<< /Type /Type1 /Subtype >>");
-        let expected_error =
-            ParseErr::Failure(ParseFailure::Dictionary(DictionaryFailure::MissingValue {
-                key: Name::from("Subtype"),
-                input: ">>".to_string(),
-            }));
+        let expected_error = ParseFailure {
+            buffer: b">>",
+            object: stringify!(Dictionary),
+            code: ParseErrorCode::RecMissingValue(
+                Name::from("Subtype"),
+                Box::new(ParseErrorCode::NotFoundUnion),
+            ),
+        };
         assert_err_eq!(parsed_result, expected_error);
     }
 

--- a/src/object/direct/name.rs
+++ b/src/object/direct/name.rs
@@ -11,7 +11,6 @@ use self::error::NameRecoverable;
 use crate::fmt::debug_bytes;
 use crate::parse::character_set::printable_token;
 use crate::parse::error::ParseErr;
-use crate::parse::error::ParseRecoverable;
 use crate::parse::error::ParseResult;
 use crate::parse::Parser;
 use crate::parse_error;

--- a/src/object/direct/null.rs
+++ b/src/object/direct/null.rs
@@ -8,7 +8,6 @@ use ::std::fmt::Result as FmtResult;
 use self::error::NullRecoverable;
 use crate::fmt::debug_bytes;
 use crate::parse::error::ParseErr;
-use crate::parse::error::ParseRecoverable;
 use crate::parse::error::ParseResult;
 use crate::parse::Parser;
 use crate::parse::KW_NULL;

--- a/src/object/direct/null.rs
+++ b/src/object/direct/null.rs
@@ -5,13 +5,13 @@ use ::std::fmt::Display;
 use ::std::fmt::Formatter;
 use ::std::fmt::Result as FmtResult;
 
-use self::error::NullRecoverable;
-use crate::fmt::debug_bytes;
 use crate::parse::error::ParseErr;
+use crate::parse::error::ParseErrorCode;
+use crate::parse::error::ParseRecoverable;
 use crate::parse::error::ParseResult;
 use crate::parse::Parser;
 use crate::parse::KW_NULL;
-use crate::parse_error;
+use crate::parse_recoverable;
 use crate::Byte;
 
 /// REFERENCE: [7.3.9 Null object, p33]
@@ -24,28 +24,18 @@ impl Display for Null {
     }
 }
 
-impl Parser for Null {
+impl Parser<'_> for Null {
     fn parse(buffer: &[Byte]) -> ParseResult<(&[Byte], Self)> {
-        let (buffer, _) = tag::<_, _, NomError<_>>(KW_NULL)(buffer).map_err(parse_error!(
+        let (buffer, _) = tag::<_, _, NomError<_>>(KW_NULL)(buffer).map_err(parse_recoverable!(
             e,
-            NullRecoverable::NotFound {
-                code: e.code,
-                input: debug_bytes(e.input),
+            ParseRecoverable {
+                buffer: e.input,
+                object: stringify!(Null),
+                code: ParseErrorCode::NotFound(e.code),
             }
         ))?;
 
         Ok((buffer, Self))
-    }
-}
-
-pub(crate) mod error {
-    use ::nom::error::ErrorKind;
-    use ::thiserror::Error;
-
-    #[derive(Debug, Error, PartialEq, Clone)]
-    pub enum NullRecoverable {
-        #[error("Not found: {code:?}. Input: {input}")]
-        NotFound { code: ErrorKind, input: String },
     }
 }
 
@@ -70,13 +60,12 @@ mod tests {
     fn null_invalid() {
         // Null: Not found
         let parse_result = Null::parse(b"nul");
-        let expected_error = ParseErr::Error(
-            NullRecoverable::NotFound {
-                code: ErrorKind::Tag,
-                input: "nul".to_string(),
-            }
-            .into(),
-        );
+        let expected_error = ParseRecoverable {
+            buffer: b"nul",
+            object: stringify!(Null),
+            code: ParseErrorCode::NotFound(ErrorKind::Tag),
+        };
+
         assert_err_eq!(parse_result, expected_error);
     }
 }

--- a/src/object/direct/numeric/integer.rs
+++ b/src/object/direct/numeric/integer.rs
@@ -13,7 +13,6 @@ use ::std::fmt::Result as FmtResult;
 use self::error::IntegerRecoverable;
 use crate::fmt::debug_bytes;
 use crate::parse::error::ParseErr;
-use crate::parse::error::ParseRecoverable;
 use crate::parse::error::ParseResult;
 use crate::parse::num::ascii_to_i128;
 use crate::parse::Parser;

--- a/src/object/direct/numeric/real.rs
+++ b/src/object/direct/numeric/real.rs
@@ -12,14 +12,14 @@ use ::std::fmt::Display;
 use ::std::fmt::Formatter;
 use ::std::fmt::Result as FmtResult;
 
-use self::error::RealFailure;
-use self::error::RealRecoverable;
-use crate::fmt::debug_bytes;
 use crate::parse::error::ParseErr;
+use crate::parse::error::ParseErrorCode;
+use crate::parse::error::ParseFailure;
+use crate::parse::error::ParseRecoverable;
 use crate::parse::error::ParseResult;
 use crate::parse::num::ascii_to_f64;
 use crate::parse::Parser;
-use crate::parse_error;
+use crate::parse_recoverable;
 use crate::Byte;
 
 #[derive(Debug, PartialEq, Clone, Copy)]
@@ -31,7 +31,7 @@ impl Display for Real {
     }
 }
 
-impl Parser for Real {
+impl Parser<'_> for Real {
     fn parse(buffer: &[Byte]) -> ParseResult<(&[Byte], Self)> {
         // REFERENCE: [7.3.3 Numeric objects, p24]
         // A real number is represented in its decimal form and does not permit
@@ -44,11 +44,12 @@ impl Parser for Real {
                 recognize(pair(digit0, preceded(char('.'), digit1))),
             )),
         ))(buffer)
-        .map_err(parse_error!(
+        .map_err(parse_recoverable!(
             e,
-            RealRecoverable::NotFound {
-                code: e.code,
-                input: debug_bytes(e.input),
+            ParseRecoverable {
+                buffer: e.input,
+                object: stringify!(Real),
+                code: ParseErrorCode::NotFound(e.code),
             }
         ))?;
         // Here, we know that the buffer starts with a real number, and the
@@ -56,8 +57,10 @@ impl Parser for Real {
 
         // It is not guaranteed that the string of digits and '.' is a valid
         // f64, e.g.  the value could overflow
-        let value = ascii_to_f64(value).ok_or_else(|| {
-            ParseErr::Failure(RealFailure::ParseFloatError(debug_bytes(value)).into())
+        let value = ascii_to_f64(value).ok_or_else(|| ParseFailure {
+            buffer: value,
+            object: stringify!(Real),
+            code: ParseErrorCode::ParseFloatError,
         })?;
 
         let value = Self(value);
@@ -82,23 +85,6 @@ mod convert {
         fn deref(&self) -> &Self::Target {
             &self.0
         }
-    }
-}
-
-pub(crate) mod error {
-    use ::nom::error::ErrorKind;
-    use ::thiserror::Error;
-
-    #[derive(Debug, Error, PartialEq, Clone)]
-    pub enum RealRecoverable {
-        #[error("Not found: {code:?}. Input: {input}")]
-        NotFound { code: ErrorKind, input: String },
-    }
-
-    #[derive(Debug, Error, PartialEq, Clone)]
-    pub enum RealFailure {
-        #[error("ParseFloatError: Failed to parse as f64. Input: {0}")]
-        ParseFloatError(String),
     }
 }
 
@@ -136,62 +122,68 @@ mod tests {
     fn numeric_real_invalid() {
         // Real number: Missing digits
         let real_incomplete = Real::parse(b"+.");
-        let expected_error = ParseErr::Error(
-            RealRecoverable::NotFound {
-                code: ErrorKind::Digit,
-                input: "".to_string(),
-            }
-            .into(),
-        );
+        let expected_error = ParseRecoverable {
+            buffer: b"",
+            object: stringify!(Real),
+            code: ParseErrorCode::NotFound(ErrorKind::Digit),
+        };
         assert_err_eq!(real_incomplete, expected_error);
 
         // Real number: Missing digits
         let parse_result = Real::parse(b" <");
-        let expected_error = ParseErr::Error(
-            RealRecoverable::NotFound {
-                code: ErrorKind::Char,
-                input: " <".to_string(),
-            }
-            .into(),
-        );
+        let expected_error = ParseRecoverable {
+            buffer: b" <",
+            object: stringify!(Real),
+            code: ParseErrorCode::NotFound(ErrorKind::Char),
+        };
         assert_err_eq!(parse_result, expected_error);
 
         // Real number: Missing digits
         let parse_result = Real::parse(b"+.<");
-        let expected_error = ParseErr::Error(
-            RealRecoverable::NotFound {
-                code: ErrorKind::Digit,
-                input: "<".to_string(),
-            }
-            .into(),
-        );
+        let expected_error = ParseRecoverable {
+            buffer: b"<",
+            object: stringify!(Real),
+            code: ParseErrorCode::NotFound(ErrorKind::Digit),
+        };
         assert_err_eq!(parse_result, expected_error);
 
         // TODO(QUESTION) Is there a need to allow such large numbers?
         // f64::MIN = -1.7976931348623157E+308f64
         let buffer = b"-179769313486231580000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
         let parse_result = Real::parse(buffer);
-        let expected_error =
-            ParseErr::Failure(RealFailure::ParseFloatError(debug_bytes(buffer)).into());
+        let expected_error = ParseFailure {
+            buffer,
+            object: stringify!(Real),
+            code: ParseErrorCode::ParseFloatError,
+        };
         assert_err_eq!(parse_result, expected_error);
         // f64::MAX = 1.7976931348623157E+308f64
         let buffer = b"179769313486231580000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000";
         let parse_result = Real::parse(buffer);
-        let expected_error =
-            ParseErr::Failure(RealFailure::ParseFloatError(debug_bytes(buffer)).into());
+        let expected_error = ParseFailure {
+            buffer,
+            object: stringify!(Real),
+            code: ParseErrorCode::ParseFloatError,
+        };
         assert_err_eq!(parse_result, expected_error);
         // f64::NEG_INFINITY
         let buffer = b"-179769313486231589999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999";
         let parse_result = Real::parse(buffer);
-        let expected_error =
-            ParseErr::Failure(RealFailure::ParseFloatError(debug_bytes(buffer)).into());
+        let expected_error = ParseFailure {
+            buffer,
+            object: stringify!(Real),
+            code: ParseErrorCode::ParseFloatError,
+        };
         assert_err_eq!(parse_result, expected_error);
         // f64::INFINITY
         let buffer =
             b"179769313486231589999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999";
         let parse_result = Real::parse(buffer);
-        let expected_error =
-            ParseErr::Failure(RealFailure::ParseFloatError(debug_bytes(buffer)).into());
+        let expected_error = ParseFailure {
+            buffer,
+            object: stringify!(Real),
+            code: ParseErrorCode::ParseFloatError,
+        };
         assert_err_eq!(parse_result, expected_error);
     }
 }

--- a/src/object/direct/numeric/real.rs
+++ b/src/object/direct/numeric/real.rs
@@ -16,7 +16,6 @@ use self::error::RealFailure;
 use self::error::RealRecoverable;
 use crate::fmt::debug_bytes;
 use crate::parse::error::ParseErr;
-use crate::parse::error::ParseRecoverable;
 use crate::parse::error::ParseResult;
 use crate::parse::num::ascii_to_f64;
 use crate::parse::Parser;

--- a/src/object/direct/string/hexadecimal.rs
+++ b/src/object/direct/string/hexadecimal.rs
@@ -19,8 +19,6 @@ use self::error::HexadecimalRecoverable;
 use crate::fmt::debug_bytes;
 use crate::parse::character_set::white_space_or_comment;
 use crate::parse::error::ParseErr;
-use crate::parse::error::ParseFailure;
-use crate::parse::error::ParseRecoverable;
 use crate::parse::error::ParseResult;
 use crate::parse::Parser;
 use crate::parse_error;

--- a/src/object/direct/string/literal.rs
+++ b/src/object/direct/string/literal.rs
@@ -17,14 +17,15 @@ use ::std::fmt::Display;
 use ::std::fmt::Formatter;
 use ::std::fmt::Result as FmtResult;
 
-use self::error::LiteralFailure;
-use self::error::LiteralRecoverable;
 use crate::fmt::debug_bytes;
 use crate::parse::error::ParseErr;
+use crate::parse::error::ParseErrorCode;
+use crate::parse::error::ParseFailure;
+use crate::parse::error::ParseRecoverable;
 use crate::parse::error::ParseResult;
 use crate::parse::Parser;
-use crate::parse_error;
 use crate::parse_failure;
+use crate::parse_recoverable;
 use crate::process::encoding::Encoding;
 use crate::Byte;
 use crate::Bytes;
@@ -39,7 +40,7 @@ impl Display for Literal {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         write!(f, "(")?;
         for &byte in self.0.iter() {
-            write!(f, "{}", byte as char)?;
+            write!(f, "{}", char::from(byte))?;
         }
         write!(f, ")")
     }
@@ -62,7 +63,7 @@ impl PartialEq for Literal {
     }
 }
 
-impl Parser for Literal {
+impl Parser<'_> for Literal {
     fn parse(buffer: &[Byte]) -> ParseResult<(&[Byte], Self)> {
         // NOTE: many0 does not result in Failures, so there is no need to
         // handle its errors separately from `char('<')`
@@ -73,20 +74,22 @@ impl Parser for Literal {
                 many0(pair(parse::inner_parentheses, parse::not_parentheses)),
             )),
         )(buffer)
-        .map_err(parse_error!(
+        .map_err(parse_recoverable!(
             e,
-            LiteralRecoverable::NotFound {
-                code: e.code,
-                input: debug_bytes(buffer)
+            ParseRecoverable {
+                buffer: e.input,
+                object: stringify!(Literal),
+                code: ParseErrorCode::NotFound(e.code),
             }
         ))?;
         // Here, we know that the buffer starts with a literal string, and
         // the following errors should be propagated as LiteralFailure
         let (buffer, _) = char::<_, NomError<_>>(')')(buffer).map_err(parse_failure!(
             e,
-            LiteralFailure::MissingClosing {
-                code: e.code,
-                input: debug_bytes(buffer)
+            ParseFailure {
+                buffer: e.input,
+                object: stringify!(Literal),
+                code: ParseErrorCode::MissingClosing(e.code),
             }
         ))?;
 
@@ -321,23 +324,6 @@ mod convert {
     }
 }
 
-pub(crate) mod error {
-    use ::nom::error::ErrorKind;
-    use ::thiserror::Error;
-
-    #[derive(Debug, Error, PartialEq, Clone)]
-    pub enum LiteralRecoverable {
-        #[error("Not found: {code:?}. Input: {input}")]
-        NotFound { code: ErrorKind, input: String },
-    }
-
-    #[derive(Debug, Error, PartialEq, Clone)]
-    pub enum LiteralFailure {
-        #[error("Missing Clossing: {code:?}. Input: {input}")]
-        MissingClosing { code: ErrorKind, input: String },
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use ::nom::error::ErrorKind;
@@ -377,35 +363,29 @@ string)",
         // Synthetic tests
         // Literal: Missing end parenthesis
         let parse_result = Literal::parse(b"(Unbalanced parentheses");
-        let expected_error = ParseErr::Failure(
-            LiteralFailure::MissingClosing {
-                code: ErrorKind::Char,
-                input: "".to_string(),
-            }
-            .into(),
-        );
+        let expected_error = ParseFailure {
+            buffer: b"",
+            object: stringify!(Literal),
+            code: ParseErrorCode::MissingClosing(ErrorKind::Char),
+        };
         assert_err_eq!(parse_result, expected_error);
 
         // Literal: Missing end parenthesis
         let parse_result = Literal::parse(br"(Escaped parentheses\)");
-        let expected_error = ParseErr::Failure(
-            LiteralFailure::MissingClosing {
-                code: ErrorKind::Char,
-                input: "".to_string(),
-            }
-            .into(),
-        );
+        let expected_error = ParseFailure {
+            buffer: b"",
+            object: stringify!(Literal),
+            code: ParseErrorCode::MissingClosing(ErrorKind::Char),
+        };
         assert_err_eq!(parse_result, expected_error);
 
         // Literal: Not found at the start of the buffer
         let parse_result = Literal::parse(b"Unbalanced parentheses)");
-        let expected_error = ParseErr::Error(
-            LiteralRecoverable::NotFound {
-                code: ErrorKind::Char,
-                input: "Unbalanced parentheses)".to_string(),
-            }
-            .into(),
-        );
+        let expected_error = ParseRecoverable {
+            buffer: b"Unbalanced parentheses)",
+            object: stringify!(Literal),
+            code: ParseErrorCode::NotFound(ErrorKind::Char),
+        };
         assert_err_eq!(parse_result, expected_error);
     }
 

--- a/src/object/direct/string/literal.rs
+++ b/src/object/direct/string/literal.rs
@@ -21,8 +21,6 @@ use self::error::LiteralFailure;
 use self::error::LiteralRecoverable;
 use crate::fmt::debug_bytes;
 use crate::parse::error::ParseErr;
-use crate::parse::error::ParseFailure;
-use crate::parse::error::ParseRecoverable;
 use crate::parse::error::ParseResult;
 use crate::parse::Parser;
 use crate::parse_error;

--- a/src/object/indirect/id.rs
+++ b/src/object/indirect/id.rs
@@ -1,19 +1,20 @@
+use ::nom::character::complete::digit1;
 use ::nom::sequence::pair;
 use ::nom::sequence::terminated;
 use ::nom::Err as NomErr;
 use ::std::fmt::Display;
 use ::std::fmt::Formatter;
 use ::std::fmt::Result as FmtResult;
-use ::std::num::ParseIntError;
 
-use self::error::IdRecoverable;
-use crate::fmt::debug_bytes;
-use crate::parse::character_set::number1;
 use crate::parse::character_set::white_space_or_comment;
 use crate::parse::error::ParseErr;
+use crate::parse::error::ParseErrorCode;
+use crate::parse::error::ParseRecoverable;
 use crate::parse::error::ParseResult;
+use crate::parse::num::ascii_to_u16;
+use crate::parse::num::ascii_to_u64;
 use crate::parse::Parser;
-use crate::parse_error;
+use crate::parse_recoverable;
 use crate::Byte;
 use crate::GenerationNumber;
 use crate::ObjectNumber;
@@ -32,33 +33,37 @@ impl Display for Id {
     }
 }
 
-impl Parser for Id {
+impl Parser<'_> for Id {
     fn parse(buffer: &[Byte]) -> ParseResult<(&[Byte], Self)> {
-        let (buffer, (object_number, generation)) = pair(
-            terminated(number1, white_space_or_comment),
-            terminated(number1, white_space_or_comment),
+        let (buffer, (object_number, generation_number)) = pair(
+            terminated(digit1, white_space_or_comment),
+            terminated(digit1, white_space_or_comment),
         )(buffer)
-        .map_err(parse_error!(
+        .map_err(parse_recoverable!(
             e,
-            IdRecoverable::NotFound {
-                code: e.code,
-                input: debug_bytes(buffer),
+            ParseRecoverable {
+                buffer: e.input,
+                object: stringify!(Id),
+                code: ParseErrorCode::NotFound(e.code)
             }
         ))?;
         // This method should not return failure, as the pair of numbers could
         // be part of an array of numbers, not an Id.
 
-        let object_number = object_number.parse().map_err(|err: ParseIntError| {
-            ParseErr::Error(
-                IdRecoverable::ObjectNumber(err.kind().clone(), object_number.to_string()).into(),
-            )
-        })?;
+        let object_number = ascii_to_u64(object_number)
+            .and_then(ObjectNumber::new)
+            .ok_or_else(|| ParseRecoverable {
+                buffer: object_number,
+                object: stringify!(Id),
+                code: ParseErrorCode::ObjectNumber,
+            })?;
 
-        let generation_number = generation.parse().map_err(|err: ParseIntError| {
-            ParseErr::Error(
-                IdRecoverable::GenerationNumber(err.kind().clone(), generation.to_string()).into(),
-            )
-        })?;
+        let generation_number =
+            ascii_to_u16(generation_number).ok_or_else(|| ParseRecoverable {
+                buffer: generation_number,
+                object: stringify!(Id),
+                code: ParseErrorCode::GenerationNumber,
+            })?;
 
         let id = Self {
             object_number,
@@ -84,26 +89,10 @@ mod convert {
     }
 }
 
-pub(crate) mod error {
-    use ::nom::error::ErrorKind;
-    use ::std::num::IntErrorKind;
-    use ::thiserror::Error;
-
-    #[derive(Debug, Error, PartialEq, Clone)]
-    pub enum IdRecoverable {
-        #[error("Invalid object number: {0:?}. Input: {1}")]
-        ObjectNumber(IntErrorKind, String),
-        #[error("Invalid generation number: {0:?}. Input: {1}")]
-        GenerationNumber(IntErrorKind, String),
-        #[error("Not found: {code:?}. Input: {input}")]
-        NotFound { code: ErrorKind, input: String },
-    }
-}
-
 #[cfg(test)]
 mod tests {
+
     use ::nom::error::ErrorKind;
-    use ::std::num::IntErrorKind;
 
     use super::*;
     use crate::assert_err_eq;
@@ -135,68 +124,66 @@ mod tests {
         // Synthetic tests
         // Id: Not found
         let parse_result = Id::parse(b"/Name");
-        let expected_error = ParseErr::Error(
-            IdRecoverable::NotFound {
-                code: ErrorKind::Digit,
-                input: "/Name".to_string(),
-            }
-            .into(),
-        );
+        let expected_error = ParseRecoverable {
+            buffer: b"/Name",
+            object: stringify!(Id),
+            code: ParseErrorCode::NotFound(ErrorKind::Digit),
+        };
+
         assert_err_eq!(parse_result, expected_error);
 
         // Id: Missing generation number
-        let parse_result = Id::parse(b"56789");
-        let expected_error = ParseErr::Error(
-            IdRecoverable::NotFound {
-                code: ErrorKind::Char,
-                input: "56789".to_string(),
-            }
-            .into(),
-        );
+        let parse_result = Id::parse(b"56789 ");
+        let expected_error = ParseRecoverable {
+            buffer: b"",
+            object: stringify!(Id),
+            code: ParseErrorCode::NotFound(ErrorKind::Digit),
+        };
         assert_err_eq!(parse_result, expected_error);
 
         // Id: Starts with a negative number
         let parse_result = Id::parse(b"-12345 65535 R other objects");
-        let expected_error = ParseErr::Error(
-            IdRecoverable::NotFound {
-                code: ErrorKind::Digit,
-                input: "-12345 65535 R other objects".to_string(),
-            }
-            .into(),
-        );
+        let expected_error = ParseRecoverable {
+            buffer: b"-12345 65535 R other objects",
+            object: stringify!(Id),
+            code: ParseErrorCode::NotFound(ErrorKind::Digit),
+        };
         assert_err_eq!(parse_result, expected_error);
 
         // Id: Zero Object number
         let parse_result = Id::parse(b"0 65535 R other objects");
-        let expected_error = ParseErr::Error(
-            IdRecoverable::ObjectNumber(IntErrorKind::Zero, "0".to_string()).into(),
-        );
+        let expected_error = ParseRecoverable {
+            buffer: b"0",
+            object: stringify!(Id),
+            code: ParseErrorCode::ObjectNumber,
+        };
         assert_err_eq!(parse_result, expected_error);
 
         // Id: Object number too large
         let parse_result = Id::parse(b"98765432109876543210 65535 R other objects");
-        let expected_error = ParseErr::Error(
-            IdRecoverable::ObjectNumber(
-                IntErrorKind::PosOverflow,
-                "98765432109876543210".to_string(),
-            )
-            .into(),
-        );
+        let expected_error = ParseRecoverable {
+            buffer: b"98765432109876543210",
+            object: stringify!(Id),
+            code: ParseErrorCode::ObjectNumber,
+        };
         assert_err_eq!(parse_result, expected_error);
 
         // Id: Generation number too large
         let parse_result = Id::parse(b"1 65536 R other objects");
-        let expected_error = ParseErr::Error(
-            IdRecoverable::GenerationNumber(IntErrorKind::PosOverflow, "65536".to_string()).into(),
-        );
+        let expected_error = ParseRecoverable {
+            buffer: b"65536",
+            object: stringify!(Id),
+            code: ParseErrorCode::GenerationNumber,
+        };
         assert_err_eq!(parse_result, expected_error);
 
         // Id: Generation number too large
         let parse_result = Id::parse(b"1 6553500 R other objects");
-        let expected_error = ParseErr::Error(
-            IdRecoverable::GenerationNumber(IntErrorKind::PosOverflow, "6553500".to_string())
-                .into(),
-        );
+        let expected_error = ParseRecoverable {
+            buffer: b"6553500",
+            object: stringify!(Id),
+            code: ParseErrorCode::GenerationNumber,
+        };
         assert_err_eq!(parse_result, expected_error);
     }
 }

--- a/src/object/indirect/id.rs
+++ b/src/object/indirect/id.rs
@@ -11,7 +11,6 @@ use crate::fmt::debug_bytes;
 use crate::parse::character_set::number1;
 use crate::parse::character_set::white_space_or_comment;
 use crate::parse::error::ParseErr;
-use crate::parse::error::ParseRecoverable;
 use crate::parse::error::ParseResult;
 use crate::parse::Parser;
 use crate::parse_error;

--- a/src/object/indirect/object.rs
+++ b/src/object/indirect/object.rs
@@ -16,8 +16,6 @@ use super::Parser;
 use crate::fmt::debug_bytes;
 use crate::parse::character_set::white_space_or_comment;
 use crate::parse::error::ParseErr;
-use crate::parse::error::ParseFailure;
-use crate::parse::error::ParseRecoverable;
 use crate::parse::error::ParseResult;
 use crate::parse::KW_ENDOBJ;
 use crate::parse::KW_OBJ;

--- a/src/object/indirect/reference.rs
+++ b/src/object/indirect/reference.rs
@@ -10,7 +10,6 @@ use self::error::ReferenceRecoverable;
 use super::id::Id;
 use crate::fmt::debug_bytes;
 use crate::parse::error::ParseErr;
-use crate::parse::error::ParseRecoverable;
 use crate::parse::error::ParseResult;
 use crate::parse::Parser;
 use crate::parse::KW_R;

--- a/src/object/indirect/reference.rs
+++ b/src/object/indirect/reference.rs
@@ -1,19 +1,18 @@
 use ::nom::bytes::complete::tag;
 use ::nom::error::Error as NomError;
-use ::nom::error::ErrorKind;
 use ::nom::Err as NomErr;
 use ::std::fmt::Display;
 use ::std::fmt::Formatter;
 use ::std::fmt::Result as FmtResult;
 
-use self::error::ReferenceRecoverable;
 use super::id::Id;
-use crate::fmt::debug_bytes;
 use crate::parse::error::ParseErr;
+use crate::parse::error::ParseErrorCode;
+use crate::parse::error::ParseRecoverable;
 use crate::parse::error::ParseResult;
 use crate::parse::Parser;
 use crate::parse::KW_R;
-use crate::parse_error;
+use crate::parse_recoverable;
 use crate::Byte;
 
 /// REFERENCE: [7.3.10 Indirect Objects, p33]
@@ -26,27 +25,24 @@ impl Display for Reference {
     }
 }
 
-impl Parser for Reference {
+impl Parser<'_> for Reference {
     fn parse(buffer: &[Byte]) -> ParseResult<(&[Byte], Self)> {
-        let (buffer, id) = Id::parse_semi_quiet(buffer).unwrap_or_else(|| {
-            Err(ParseErr::Error(
-                ReferenceRecoverable::NotFound {
-                    code: ErrorKind::Digit,
-                    input: debug_bytes(buffer),
-                }
-                .into(),
-            ))
+        let (buffer, id) = Id::parse(buffer).map_err(|err| ParseRecoverable {
+            buffer: err.buffer(),
+            object: stringify!(Reference),
+            code: ParseErrorCode::RecNotFound(Box::new(err.code())),
         })?;
         // At this point, even though we have an Id, it is unclear if it is a
         // reference or a sequence of integers. For example, `12 0` appearing in
         // an array can be part of the indirect reference `12 0 R` or simply a
         // pair of integers in that array.
         let (buffer, _) =
-            tag::<_, _, NomError<_>>(KW_R.as_bytes())(buffer).map_err(parse_error!(
+            tag::<_, _, NomError<_>>(KW_R.as_bytes())(buffer).map_err(parse_recoverable!(
                 e,
-                ReferenceRecoverable::NotFound {
-                    code: e.code,
-                    input: debug_bytes(e.input),
+                ParseRecoverable {
+                    buffer: e.input,
+                    object: stringify!(Reference),
+                    code: ParseErrorCode::NotFound(e.code),
                 }
             ))?;
 
@@ -75,20 +71,9 @@ mod convert {
     }
 }
 
-pub(crate) mod error {
-
-    use ::nom::error::ErrorKind;
-    use ::thiserror::Error;
-
-    #[derive(Debug, Error, PartialEq, Clone)]
-    pub enum ReferenceRecoverable {
-        #[error("Not found: {code:?}. Input: {input}")]
-        NotFound { code: ErrorKind, input: String },
-    }
-}
-
 #[cfg(test)]
 mod tests {
+
     use ::nom::error::ErrorKind;
 
     use super::*;
@@ -124,46 +109,39 @@ mod tests {
         // Synthetic tests
         // Reference: Incomplete
         let parse_result = Reference::parse(b"1 0");
-        let expected_error = ParseErr::Error(
-            ReferenceRecoverable::NotFound {
-                code: ErrorKind::Digit,
-                input: "1 0".to_string(),
-            }
-            .into(),
-        );
+        let expected_error = ParseRecoverable {
+            buffer: b"",
+            object: stringify!(Reference),
+            code: ParseErrorCode::RecNotFound(Box::new(ParseErrorCode::NotFound(ErrorKind::Char))),
+        };
         assert_err_eq!(parse_result, expected_error);
 
         // Reference: Id not found
         let parse_result = Reference::parse(b"/Name");
-        let expected_error = ParseErr::Error(
-            ReferenceRecoverable::NotFound {
-                code: ErrorKind::Digit,
-                input: "/Name".to_string(),
-            }
-            .into(),
-        );
+        let expected_error = ParseRecoverable {
+            buffer: b"/Name",
+            object: stringify!(Reference),
+            code: ParseErrorCode::RecNotFound(Box::new(ParseErrorCode::NotFound(ErrorKind::Digit))),
+        };
+
         assert_err_eq!(parse_result, expected_error);
 
         // Reference: Id error
         let parse_result = Reference::parse(b"0 65535 R other objects");
-        let expected_error = ParseErr::Error(
-            ReferenceRecoverable::NotFound {
-                code: ErrorKind::Digit,
-                input: "0 65535 R other objects".to_string(),
-            }
-            .into(),
-        );
+        let expected_error = ParseRecoverable {
+            buffer: b"0",
+            object: stringify!(Reference),
+            code: ParseErrorCode::RecNotFound(Box::new(ParseErrorCode::ObjectNumber)),
+        };
         assert_err_eq!(parse_result, expected_error);
 
         // Reference: Not found
         let parse_result = Reference::parse(b"12345 65535 <");
-        let expected_error = ParseErr::Error(
-            ReferenceRecoverable::NotFound {
-                code: ErrorKind::Tag,
-                input: "<".to_string(),
-            }
-            .into(),
-        );
+        let expected_error = ParseRecoverable {
+            buffer: b"<",
+            object: stringify!(Reference),
+            code: ParseErrorCode::NotFound(ErrorKind::Tag),
+        };
         assert_err_eq!(parse_result, expected_error);
     }
 }

--- a/src/object/indirect/stream.rs
+++ b/src/object/indirect/stream.rs
@@ -18,7 +18,6 @@ use crate::parse::character_set::eol;
 use crate::parse::character_set::white_space_or_comment;
 use crate::parse::error::ParseErr;
 use crate::parse::error::ParseFailure;
-use crate::parse::error::ParseRecoverable;
 use crate::parse::error::ParseResult;
 use crate::parse::Parser;
 use crate::parse::KW_ENDSTREAM;

--- a/src/object/indirect/stream.rs
+++ b/src/object/indirect/stream.rs
@@ -10,20 +10,19 @@ use ::nom::Err as NomErr;
 use ::std::fmt::Debug;
 use ::std::fmt::Display;
 
-use self::error::StreamFailure;
-use self::error::StreamRecoverable;
-use crate::fmt::debug_bytes;
 use crate::object::direct::dictionary::Dictionary;
 use crate::parse::character_set::eol;
 use crate::parse::character_set::white_space_or_comment;
 use crate::parse::error::ParseErr;
+use crate::parse::error::ParseErrorCode;
 use crate::parse::error::ParseFailure;
+use crate::parse::error::ParseRecoverable;
 use crate::parse::error::ParseResult;
 use crate::parse::Parser;
 use crate::parse::KW_ENDSTREAM;
 use crate::parse::KW_STREAM;
-use crate::parse_error;
 use crate::parse_failure;
+use crate::parse_recoverable;
 use crate::Byte;
 use crate::Bytes;
 
@@ -46,7 +45,7 @@ impl Display for Stream {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}\n{}\n", self.dictionary, KW_STREAM)?;
         for &byte in self.data.iter() {
-            write!(f, "{}", byte as char)?;
+            write!(f, "{}", char::from(byte))?;
         }
         write!(f, "\n{}", KW_ENDSTREAM)
     }
@@ -54,51 +53,50 @@ impl Display for Stream {
 
 impl Debug for Stream {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}\n{}\n{}\n{}",
-            self.dictionary,
-            KW_STREAM,
-            debug_bytes(&self.data),
-            KW_ENDSTREAM
-        )
+        writeln!(f, "{}\n{}", self.dictionary, KW_STREAM)?;
+        for &byte in self.data.iter() {
+            write!(f, "{}", char::from(byte))?;
+        }
+        write!(f, "\n{}", KW_ENDSTREAM)
     }
 }
 
-impl Parser for Stream {
+impl Parser<'_> for Stream {
     /// REFERENCE: [7.3.8 Stream objects, p31-32]
     fn parse(buffer: &[Byte]) -> ParseResult<(&[Byte], Self)> {
-        let (buffer, dictionary) = Dictionary::parse_semi_quiet::<Dictionary>(buffer)
-            .unwrap_or_else(|| {
-                Err(ParseErr::Error(
-                    StreamRecoverable::DictionaryNotFound(debug_bytes(buffer)).into(),
-                ))
-            })?;
+        let (remains, dictionary) = Dictionary::parse(buffer)?;
 
-        let (buffer, _) = tuple((
+        let (remains, _) = tuple((
             opt(white_space_or_comment),
             tag(KW_STREAM),
             preceded(opt(char('\r')), char('\n')),
-        ))(buffer)
-        .map_err(parse_error!(
+        ))(remains)
+        .map_err(parse_recoverable!(
             e,
-            StreamRecoverable::NotFound {
-                code: e.code,
-                input: debug_bytes(e.input),
+            ParseRecoverable {
+                buffer: e.input,
+                object: stringify!(Stream),
+                code: ParseErrorCode::NotFound(e.code),
             }
         ))?;
         // Here, we know that the buffer starts with a stream, and the following
         // errors should be propagated as StreamFailure
 
         let length = dictionary
-            .get_u64(KEY_LENGTH)
-            .map_err(|err| ParseErr::Failure(StreamFailure::LengthDatatype(err.value).into()))?
+            .get_usize(KEY_LENGTH)
+            .map_err(|err| ParseFailure {
+                buffer, // TODO (TEMP) Replace with dictionary.as_bytes() when implemented
+                object: stringify!(Stream),
+                code: err.into(),
+            })?
             .ok_or_else(|| {
-                ParseErr::Failure(StreamFailure::LengthNotFound(dictionary.to_string()).into())
+                ParseFailure {
+                    buffer, // TODO (TEMP) Replace with dictionary.as_bytes() when implemented
+                    object: stringify!(Stream),
+                    code: ParseErrorCode::RecMissingKey(KEY_LENGTH),
+                }
             })?;
-
-        let length = usize::try_from(length)
-            .map_err(|_| ParseErr::Failure(StreamFailure::LengthInvalidValue(length).into()))?;
+        let buffer = remains;
 
         // FIXME Add support for indirect reference
         // DirectValue::Reference(_reference) => {
@@ -112,9 +110,10 @@ impl Parser for Stream {
 
         let (buffer, data) = take::<_, _, NomError<_>>(length)(buffer).map_err(parse_failure!(
             e,
-            StreamFailure::StreamData {
-                kind: e.code,
-                input: debug_bytes(e.input),
+            ParseFailure {
+                buffer: e.input,
+                object: stringify!(Stream),
+                code: ParseErrorCode::MissingData(e.code),
             }
         ))?;
 
@@ -123,9 +122,10 @@ impl Parser for Stream {
         )
         .map_err(parse_failure!(
             e,
-            StreamFailure::MissingClosing {
-                kind: e.code,
-                input: debug_bytes(e.input)
+            ParseFailure {
+                buffer: e.input,
+                object: stringify!(Stream),
+                code: ParseErrorCode::MissingClosing(e.code),
             }
         ))?;
 
@@ -180,6 +180,7 @@ mod convert {
 
     use super::*;
     use crate::object::indirect::IndirectValue;
+    use crate::parse::error::ParseFailure;
 
     impl Stream {
         pub(crate) fn new(dictionary: impl Into<Dictionary>, data: impl Into<Bytes>) -> Self {
@@ -191,44 +192,19 @@ mod convert {
     }
 
     impl TryFrom<IndirectValue> for Stream {
-        type Error = ParseFailure;
+        type Error = ParseFailure<'static>;
 
         fn try_from(value: IndirectValue) -> Result<Self, Self::Error> {
             if let IndirectValue::Stream(stream) = value {
                 Ok(stream)
             } else {
-                Err(StreamFailure::WrongDataType(stringify!(Stream), value.to_string()).into())
+                Err(ParseFailure {
+                    buffer: &[], // TODO (TEMP) Replace with value.as_bytes() when implemented
+                    object: stringify!(Stream),
+                    code: ParseErrorCode::ObjectType,
+                })
             }
         }
-    }
-}
-
-pub(crate) mod error {
-    use ::nom::error::ErrorKind;
-    use ::thiserror::Error;
-
-    #[derive(Debug, Error, PartialEq, Clone)]
-    pub enum StreamRecoverable {
-        #[error("Dictionary not found: {0}")]
-        DictionaryNotFound(String),
-        #[error("Not found: {code:?}. Input: {input}")]
-        NotFound { code: ErrorKind, input: String },
-    }
-
-    #[derive(Debug, Error, PartialEq, Clone)]
-    pub enum StreamFailure {
-        #[error("Length entry not found. Dictionary: {0}")]
-        LengthNotFound(String),
-        #[error("Length entry has the wrong data type. Input: {0}")]
-        LengthDatatype(String),
-        #[error("Length entry has invalid value. Input: {0}")]
-        LengthInvalidValue(u64),
-        #[error("Failed to parse stream data: {kind:?}. Input: {input}")]
-        StreamData { kind: ErrorKind, input: String },
-        #[error("Missing Closing: {kind:?}. Input: {input}")]
-        MissingClosing { kind: ErrorKind, input: String },
-        #[error("Wrong data type.  Expected a {0} value, found {1}")]
-        WrongDataType(&'static str, String),
     }
 }
 
@@ -239,9 +215,11 @@ mod tests {
     use super::*;
     use crate::assert_err_eq;
     use crate::object::direct::array::Array;
+    use crate::object::direct::dictionary::error::DataTypeError;
     use crate::object::direct::name::Name;
     use crate::object::direct::string::Hexadecimal;
     use crate::object::indirect::reference::Reference;
+    use crate::parse::error::ParseFailure;
     use crate::parse_assert_eq;
     use crate::Byte;
 
@@ -281,14 +259,27 @@ mod tests {
         // Synthetic tests
         // Stream: Length not found in stream dictionary
         let parse_result = Stream::parse(b"<<>>\nstream\nendstream");
-        let expected_error = ParseErr::Failure(StreamFailure::LengthNotFound("<<>>".into()).into());
+        let expected_error = ParseFailure {
+            buffer: b"<<>>\nstream\nendstream", // TODO (TEMP) b"<<>>"
+            object: stringify!(Stream),
+            code: ParseErrorCode::RecMissingKey(KEY_LENGTH),
+        };
         assert_err_eq!(parse_result, expected_error);
 
         // Stream: Length has the wrong type. Only NonNegative values and References are
         // allowed for Length Stream: Length of invalid value: -1
         let parse_result = Stream::parse(b"<</Length -1>>\nstream\nendstream");
-        let expected_error =
-            ParseErr::Failure(StreamFailure::LengthDatatype("-1".to_string()).into());
+        let expected_error = ParseFailure {
+            buffer: b"<</Length -1>>\nstream\nendstream", // TODO(TEMP) b"-1",
+            object: stringify!(Stream),
+            code: DataTypeError {
+                entry: KEY_LENGTH,
+                expected_type: stringify!(usize),
+                value: "-1".to_string(),
+                object: "<</Length -1>>".to_string(),
+            }
+            .into(),
+        };
         assert_err_eq!(parse_result, expected_error);
 
         // TODO StreamFailure::LengthInvalidValue should be returned on machines
@@ -296,24 +287,20 @@ mod tests {
 
         // Stream: Data is too short
         let parse_result = Stream::parse(b"<</Length 10>>\nstream\n0123456\nendstream");
-        let expected_error = ParseErr::Failure(
-            StreamFailure::MissingClosing {
-                kind: ErrorKind::Tag,
-                input: "dstream".to_string(),
-            }
-            .into(),
-        );
+        let expected_error = ParseFailure {
+            buffer: b"dstream",
+            object: stringify!(Stream),
+            code: ParseErrorCode::MissingClosing(ErrorKind::Tag),
+        };
         assert_err_eq!(parse_result, expected_error);
 
         // Stream: Data is too long
         let parse_result = Stream::parse(b"<</Length 5>>\nstream\n0123456789\nendstream");
-        let expected_error = ParseErr::Failure(
-            StreamFailure::MissingClosing {
-                kind: ErrorKind::Tag,
-                input: "56789\nendstream".to_string(),
-            }
-            .into(),
-        );
+        let expected_error = ParseFailure {
+            buffer: b"56789\nendstream",
+            object: stringify!(Stream),
+            code: ParseErrorCode::MissingClosing(ErrorKind::Tag),
+        };
         assert_err_eq!(parse_result, expected_error);
     }
 }

--- a/src/parse/character_set.rs
+++ b/src/parse/character_set.rs
@@ -4,7 +4,6 @@ use ::nom::bytes::complete::take_till;
 use ::nom::bytes::complete::take_while;
 use ::nom::bytes::complete::take_while1;
 use ::nom::character::complete::char;
-use ::nom::character::complete::digit0;
 use ::nom::character::complete::digit1;
 use ::nom::combinator::opt;
 use ::nom::combinator::recognize;
@@ -98,21 +97,9 @@ pub(crate) fn printable_token(buffer: &[Byte]) -> IResult<&[Byte], &[Byte]> {
     take_while1(is_printable_regular)(buffer)
 }
 
+// TODO Replace with digit1
 pub(crate) fn number1(buffer: &[Byte]) -> IResult<&[Byte], &str> {
     let (buffer, number) = digit1(buffer)?;
-    let number = if let Ok(number) = ::std::str::from_utf8(number) {
-        number
-    } else {
-        return Err(NomErr::Failure(NomError {
-            input: number,
-            code: ErrorKind::Digit,
-        }));
-    };
-    Ok((buffer, number))
-}
-
-pub(crate) fn number0(buffer: &[Byte]) -> IResult<&[Byte], &str> {
-    let (buffer, number) = digit0(buffer)?;
     let number = if let Ok(number) = ::std::str::from_utf8(number) {
         number
     } else {
@@ -408,13 +395,5 @@ mod tests {
             ErrorKind::Digit,
         )));
         assert_eq!(parse_result, expected_error);
-    }
-
-    #[test]
-    fn number0_valid() {
-        assert_eq!(number0(b"123 ").unwrap(), (b" ".as_slice(), "123"));
-        assert_eq!(number0(b"0 ").unwrap(), (b" ".as_slice(), "0"));
-        assert_eq!(number0(b"R").unwrap(), (b"R".as_slice(), ""));
-        assert_eq!(number0(b".123").unwrap(), (b".123".as_slice(), ""));
     }
 }

--- a/src/parse/character_set.rs
+++ b/src/parse/character_set.rs
@@ -4,15 +4,11 @@ use ::nom::bytes::complete::take_till;
 use ::nom::bytes::complete::take_while;
 use ::nom::bytes::complete::take_while1;
 use ::nom::character::complete::char;
-use ::nom::character::complete::digit1;
 use ::nom::combinator::opt;
 use ::nom::combinator::recognize;
-use ::nom::error::Error as NomError;
-use ::nom::error::ErrorKind;
 use ::nom::multi::many1;
 use ::nom::sequence::delimited;
 use ::nom::sequence::preceded;
-use ::nom::Err as NomErr;
 use ::nom::IResult;
 
 use crate::fmt::debug_bytes;
@@ -97,22 +93,12 @@ pub(crate) fn printable_token(buffer: &[Byte]) -> IResult<&[Byte], &[Byte]> {
     take_while1(is_printable_regular)(buffer)
 }
 
-// TODO Replace with digit1
-pub(crate) fn number1(buffer: &[Byte]) -> IResult<&[Byte], &str> {
-    let (buffer, number) = digit1(buffer)?;
-    let number = if let Ok(number) = ::std::str::from_utf8(number) {
-        number
-    } else {
-        return Err(NomErr::Failure(NomError {
-            input: number,
-            code: ErrorKind::Digit,
-        }));
-    };
-    Ok((buffer, number))
-}
-
 #[cfg(test)]
 mod tests {
+    use ::nom::error::Error as NomError;
+    use ::nom::error::ErrorKind;
+    use ::nom::Err as NomErr;
+
     use super::*;
 
     #[test]
@@ -370,29 +356,6 @@ mod tests {
         let expected_error = Err(NomErr::Error(NomError::new(
             [0x80, 0x81, 0x82, 0x83].as_slice(),
             ErrorKind::TakeWhile1,
-        )));
-        assert_eq!(parse_result, expected_error);
-    }
-
-    #[test]
-    fn number1_valid() {
-        assert_eq!(number1(b"123 ").unwrap(), (b" ".as_slice(), "123"));
-        assert_eq!(number1(b"0<").unwrap(), (b"<".as_slice(), "0"));
-    }
-
-    #[test]
-    fn number1_invalid() {
-        let parse_result = number1(b".123");
-        let expected_error = Err(NomErr::Error(NomError::new(
-            ".123".as_bytes(),
-            ErrorKind::Digit,
-        )));
-        assert_eq!(parse_result, expected_error);
-
-        let parse_result = number1(b"R");
-        let expected_error = Err(NomErr::Error(NomError::new(
-            "R".as_bytes(),
-            ErrorKind::Digit,
         )));
         assert_eq!(parse_result, expected_error);
     }

--- a/src/parse/error.rs
+++ b/src/parse/error.rs
@@ -1,11 +1,12 @@
-use ::nom::Needed;
+use ::nom::error::ErrorKind;
 use ::std::str::Utf8Error;
 use ::thiserror::Error;
 
+use crate::fmt::debug_bytes;
 use crate::object::direct::array::error::ArrayFailure;
 use crate::object::direct::array::error::ArrayRecoverable;
 use crate::object::direct::boolean::error::BooleanRecoverable;
-use crate::object::direct::dictionary::error::DataTypeErr;
+use crate::object::direct::dictionary::error::DataTypeError;
 use crate::object::direct::dictionary::error::DictionaryFailure;
 use crate::object::direct::dictionary::error::DictionaryRecoverable;
 use crate::object::direct::error::DirectValueRecoverable;
@@ -27,18 +28,67 @@ use crate::object::indirect::object::error::IndirectObjectRecoverable;
 use crate::object::indirect::reference::error::ReferenceRecoverable;
 use crate::object::indirect::stream::error::StreamFailure;
 use crate::object::indirect::stream::error::StreamRecoverable;
-use crate::xref::increment::error::IncrementRecoverable;
-use crate::xref::increment::section::entry::error::EntryFailure;
-use crate::xref::increment::section::error::SectionFailure;
-use crate::xref::increment::section::error::SectionRecoverable;
-use crate::xref::increment::section::subsection::error::SubsectionFailure;
-use crate::xref::increment::section::subsection::error::SubsectionRecoverable;
-use crate::xref::increment::trailer::error::TrailerFailure;
-use crate::xref::pretable::error::PreTableFailure;
-use crate::xref::startxref::error::StartXRefFailure;
+use crate::xref::increment::error::IncrementCode;
+use crate::xref::increment::section::entry::error::EntryCode;
+use crate::xref::increment::section::error::SectionCode;
+use crate::xref::increment::section::subsection::error::SubsectionCode;
+use crate::xref::pretable::error::PreTableCode;
+use crate::xref::startxref::error::StartXRefCode;
+use crate::Byte;
 
+pub(crate) type NewParseResult<'buffer, T> = Result<T, NewParseErr<'buffer>>;
 pub(crate) type ParseResult<T> = Result<T, ParseErr>;
+/// Recoverable parsing error
+/// This error is used when the parser is unable to determine the value type
+/// and the buffer needs to be reprocessed with a different parser
+pub(crate) type NewParseRecoverable<'buffer> = ParseError<'buffer, true>;
+/// Unrecoverable parsing error
+/// This error is used when the parser is able to determine the value type
+/// but fails to parse it completely
+pub(crate) type NewParseFailure<'buffer> = ParseError<'buffer, false>;
 
+#[derive(Debug, Error, PartialEq, Clone)]
+pub enum NewParseErr<'buffer> {
+    #[error("Parse Recoverable: {0}")]
+    Recoverable(NewParseRecoverable<'buffer>),
+    #[error("Parse Failure: {0}")]
+    Failure(NewParseFailure<'buffer>),
+    // TODO(TEMP)
+    #[error("Old Parse Error: {0}")]
+    Old(#[from] ParseErr),
+}
+
+#[derive(Debug, Error, PartialEq, Clone)]
+#[error("Code: {code}. Buffer: {}", debug_bytes(.buffer))]
+pub struct ParseError<'buffer, const RECOVERABLE: bool> {
+    pub(crate) buffer: &'buffer [Byte],
+    pub(crate) code: ParseErrorCode,
+}
+
+// XRefStreamCode, SubsectionCode and SectionCode do not implement Copy
+#[derive(Debug, Error, PartialEq, Clone)]
+pub enum ParseErrorCode {
+    #[error("{0}. Not found. {}", if let Some(kind) = .1 { kind.description() } else { "" })]
+    NotFound(&'static str, Option<ErrorKind>),
+    #[error("{0}. Missing closing. Error: {}", .1.description() )]
+    MissingClosing(&'static str, ErrorKind),
+    #[error("{0}. Offset")]
+    OffSet(&'static str),
+    #[error("Increment. {0}")]
+    Increment(#[from] IncrementCode),
+    #[error("StartXRef. {0}")]
+    StartXRef(#[from] StartXRefCode),
+    #[error("PreTable. {0}")]
+    PreTable(#[from] PreTableCode),
+    #[error("Entry. {0}")]
+    Entry(#[from] EntryCode),
+    #[error("Subsection. {0}")]
+    Subsection(#[from] SubsectionCode),
+    #[error("Section. {0}")]
+    Section(#[from] SectionCode),
+}
+
+// TODO (TEMP)
 #[derive(Debug, Error, PartialEq, Clone)]
 pub enum ParseErr {
     #[error("Parse Recoverable: {0}")]
@@ -47,14 +97,9 @@ pub enum ParseErr {
     Failure(#[from] ParseFailure),
 }
 
-/// Recoverable parsing error
-/// This error is used when the parser is unable to determine the value type
-/// and the buffer needs to be reprocessed with a different parser
+// TODO (TEMP)
 #[derive(Debug, Error, PartialEq, Clone)]
 pub enum ParseRecoverable {
-    #[error("Incomplete: {0:?}")]
-    Incomplete(Needed),
-
     #[error("Null: {0}")]
     Null(#[from] NullRecoverable),
     #[error("Boolean: {0}")]
@@ -89,28 +134,15 @@ pub enum ParseRecoverable {
     IndirectValue(#[from] IndirectValueRecoverable),
     #[error("Stream: {0}")]
     Stream(#[from] StreamRecoverable),
-    #[error("Subsection: {0}")]
-    Subsection(#[from] SubsectionRecoverable),
-    #[error("Section: {0}")]
-    Section(#[from] SectionRecoverable),
-    #[error("Increment: {0}")]
-    Increment(#[from] IncrementRecoverable),
 }
 
-/// Unrecoverable parsing error
-/// This error is used when the parser is able to determine the value type
-/// but fails to parse it completely
+// TODO (TEMP)
 #[derive(Debug, Error, PartialEq, Clone)]
 pub enum ParseFailure {
-    #[error("Incomplete: {0:?}")]
-    Incomplete(Needed),
-
-    #[error("StartXRef: {0}")]
-    StartXRef(#[from] StartXRefFailure),
     // TODO Remove Utf8Error from ParseFailure
     // Utf8Error should not happen, as ::std::str::from_utf8 is only called
     // for bytes that are already validated as UTF-8
-    #[error("Utf8Error: Failed to parse as a string slice: {1}. Input: {0}")]
+    #[error("Utf8Error: Failed to parse as a string slice: {1}. Buffer: {0}")]
     Utf8Error(String, Utf8Error),
     #[error("Real: {0}")]
     Real(#[from] RealFailure),
@@ -126,27 +158,36 @@ pub enum ParseFailure {
     IndirectObject(#[from] IndirectObjectFailure),
     #[error("Stream: {0}")]
     Stream(#[from] StreamFailure),
-    #[error("Subsection: {0}")]
-    Subsection(#[from] SubsectionFailure),
-    #[error("Section: {0}")]
-    Section(#[from] SectionFailure),
-    #[error("Entry: {0}")]
-    Entry(#[from] EntryFailure),
-    #[error("Trailer: {0}")]
-    Trailer(#[from] TrailerFailure),
     // TODO Refactor if DataTypeErr is only used in ParseFailure
     #[error("DataType: {0}")]
-    DataType(#[from] DataTypeErr),
-    #[error("PreTable: {0}")]
-    PreTable(#[from] PreTableFailure),
+    DataType(#[from] DataTypeError<'static>),
+}
+
+impl NewParseErr<'_> {
+    pub fn code(&self) -> &ParseErrorCode {
+        match self {
+            Self::Recoverable(err) => &err.code,
+            Self::Failure(err) => &err.code,
+            Self::Old(_) => unimplemented!(),
+        }
+    }
+}
+
+// TODO(TEMP)
+impl ParseErr {
+    pub fn code(&self) -> &ParseErrorCode {
+        unimplemented!()
+    }
 }
 
 #[macro_export]
-macro_rules! parse_error {
-    ($e:ident, $error:expr) => {
+macro_rules! new_parse_failure {
+    ($e:ident, $failure:expr) => {
         |err| match err {
-            NomErr::Incomplete(needed) => ParseRecoverable::Incomplete(needed).into(),
-            NomErr::Error($e) | NomErr::Failure($e) => ParseErr::Error($error.into()),
+            NomErr::Incomplete(_) => unreachable!(
+                "::nom::complete functions do not return the Incomplete error variant."
+            ),
+            NomErr::Error($e) | NomErr::Failure($e) => NewParseErr::Failure($failure.into()),
         }
     };
 }
@@ -155,8 +196,57 @@ macro_rules! parse_error {
 macro_rules! parse_failure {
     ($e:ident, $failure:expr) => {
         |err| match err {
-            NomErr::Incomplete(needed) => ParseFailure::Incomplete(needed).into(),
+            NomErr::Incomplete(_) => unreachable!(
+                "::nom::complete functions do not return the Incomplete error variant."
+            ),
             NomErr::Error($e) | NomErr::Failure($e) => ParseErr::Failure($failure.into()),
         }
     };
+}
+
+#[macro_export]
+macro_rules! parse_recoverable {
+    ($e:ident, $error:expr) => {
+        |err| match err {
+            NomErr::Incomplete(_) => unreachable!(
+                "::nom::complete functions do not return the Incomplete error variant."
+            ),
+            NomErr::Error($e) | NomErr::Failure($e) => NewParseErr::Recoverable($error),
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! parse_error {
+    ($e:ident, $error:expr) => {
+        |err| match err {
+            NomErr::Incomplete(_) => unreachable!(
+                "::nom::complete functions do not return the Incomplete error variant."
+            ),
+            NomErr::Error($e) | NomErr::Failure($e) => ParseErr::Error($error.into()),
+        }
+    };
+}
+
+mod convert {
+    use super::*;
+
+    // TODO(TEMP)
+    impl<'buffer> From<ParseFailure> for NewParseErr<'buffer> {
+        fn from(err: ParseFailure) -> Self {
+            NewParseErr::Old(err.into())
+        }
+    }
+
+    impl<'buffer> From<NewParseFailure<'buffer>> for NewParseErr<'buffer> {
+        fn from(err: NewParseFailure<'buffer>) -> Self {
+            NewParseErr::Failure(err)
+        }
+    }
+
+    impl<'buffer> From<NewParseRecoverable<'buffer>> for NewParseErr<'buffer> {
+        fn from(err: NewParseRecoverable<'buffer>) -> Self {
+            NewParseErr::Recoverable(err)
+        }
+    }
 }

--- a/src/parse/error.rs
+++ b/src/parse/error.rs
@@ -1,195 +1,110 @@
 use ::nom::error::ErrorKind;
-use ::std::str::Utf8Error;
 use ::thiserror::Error;
 
 use crate::fmt::debug_bytes;
-use crate::object::direct::array::error::ArrayFailure;
-use crate::object::direct::array::error::ArrayRecoverable;
-use crate::object::direct::boolean::error::BooleanRecoverable;
 use crate::object::direct::dictionary::error::DataTypeError;
-use crate::object::direct::dictionary::error::DictionaryFailure;
-use crate::object::direct::dictionary::error::DictionaryRecoverable;
-use crate::object::direct::error::DirectValueRecoverable;
-use crate::object::direct::name::error::NameRecoverable;
-use crate::object::direct::null::error::NullRecoverable;
-use crate::object::direct::numeric::error::NumericRecoverable;
-use crate::object::direct::numeric::integer::error::IntegerRecoverable;
-use crate::object::direct::numeric::real::error::RealFailure;
-use crate::object::direct::numeric::real::error::RealRecoverable;
-use crate::object::direct::string::error::StringRecoverable;
-use crate::object::direct::string::hexadecimal::error::HexadecimalFailure;
-use crate::object::direct::string::hexadecimal::error::HexadecimalRecoverable;
-use crate::object::direct::string::literal::error::LiteralFailure;
-use crate::object::direct::string::literal::error::LiteralRecoverable;
-use crate::object::indirect::error::IndirectValueRecoverable;
-use crate::object::indirect::id::error::IdRecoverable;
-use crate::object::indirect::object::error::IndirectObjectFailure;
-use crate::object::indirect::object::error::IndirectObjectRecoverable;
-use crate::object::indirect::reference::error::ReferenceRecoverable;
-use crate::object::indirect::stream::error::StreamFailure;
-use crate::object::indirect::stream::error::StreamRecoverable;
-use crate::xref::increment::error::IncrementCode;
-use crate::xref::increment::section::entry::error::EntryCode;
-use crate::xref::increment::section::error::SectionCode;
-use crate::xref::increment::section::subsection::error::SubsectionCode;
-use crate::xref::pretable::error::PreTableCode;
-use crate::xref::startxref::error::StartXRefCode;
+use crate::object::direct::name::Name;
+use crate::process::error::NewProcessErr;
 use crate::Byte;
+use crate::ObjectNumberOrZero;
 
-pub(crate) type NewParseResult<'buffer, T> = Result<T, NewParseErr<'buffer>>;
-pub(crate) type ParseResult<T> = Result<T, ParseErr>;
+pub(crate) type ParseResult<'buffer, T> = Result<T, ParseErr<'buffer>>;
 /// Recoverable parsing error
 /// This error is used when the parser is unable to determine the value type
 /// and the buffer needs to be reprocessed with a different parser
-pub(crate) type NewParseRecoverable<'buffer> = ParseError<'buffer, true>;
+pub(crate) type ParseRecoverable<'buffer> = ParseError<'buffer, true>;
 /// Unrecoverable parsing error
 /// This error is used when the parser is able to determine the value type
 /// but fails to parse it completely
-pub(crate) type NewParseFailure<'buffer> = ParseError<'buffer, false>;
+pub(crate) type ParseFailure<'buffer> = ParseError<'buffer, false>;
 
 #[derive(Debug, Error, PartialEq, Clone)]
-pub enum NewParseErr<'buffer> {
+pub enum ParseErr<'buffer> {
     #[error("Parse Recoverable: {0}")]
-    Recoverable(NewParseRecoverable<'buffer>),
+    Recoverable(ParseRecoverable<'buffer>),
     #[error("Parse Failure: {0}")]
-    Failure(NewParseFailure<'buffer>),
-    // TODO(TEMP)
-    #[error("Old Parse Error: {0}")]
-    Old(#[from] ParseErr),
+    Failure(ParseFailure<'buffer>),
 }
 
+// TODO This type's constructors are too verbose. Use a macro to make it more
+// concise
 #[derive(Debug, Error, PartialEq, Clone)]
-#[error("Code: {code}. Buffer: {}", debug_bytes(.buffer))]
+#[error("{object}. {code}. Buffer: {}", debug_bytes(.buffer))]
 pub struct ParseError<'buffer, const RECOVERABLE: bool> {
     pub(crate) buffer: &'buffer [Byte],
+    pub(crate) object: &'static str,
     pub(crate) code: ParseErrorCode,
 }
 
-// XRefStreamCode, SubsectionCode and SectionCode do not implement Copy
+// TODO IncrementErrorCode does not implement Copy. This is due to
+// `Trailer::try_from` resulting in NewProcessErr
 #[derive(Debug, Error, PartialEq, Clone)]
 pub enum ParseErrorCode {
-    #[error("{0}. Not found. {}", if let Some(kind) = .1 { kind.description() } else { "" })]
-    NotFound(&'static str, Option<ErrorKind>),
-    #[error("{0}. Missing closing. Error: {}", .1.description() )]
-    MissingClosing(&'static str, ErrorKind),
-    #[error("{0}. Offset")]
-    OffSet(&'static str),
-    #[error("Increment. {0}")]
-    Increment(#[from] IncrementCode),
-    #[error("StartXRef. {0}")]
-    StartXRef(#[from] StartXRefCode),
-    #[error("PreTable. {0}")]
-    PreTable(#[from] PreTableCode),
-    #[error("Entry. {0}")]
-    Entry(#[from] EntryCode),
-    #[error("Subsection. {0}")]
-    Subsection(#[from] SubsectionCode),
-    #[error("Section. {0}")]
-    Section(#[from] SectionCode),
-}
-
-// TODO (TEMP)
-#[derive(Debug, Error, PartialEq, Clone)]
-pub enum ParseErr {
-    #[error("Parse Recoverable: {0}")]
-    Error(#[from] ParseRecoverable),
-    #[error("Parse Failure: {0}")]
-    Failure(#[from] ParseFailure),
-}
-
-// TODO (TEMP)
-#[derive(Debug, Error, PartialEq, Clone)]
-pub enum ParseRecoverable {
-    #[error("Null: {0}")]
-    Null(#[from] NullRecoverable),
-    #[error("Boolean: {0}")]
-    Boolean(#[from] BooleanRecoverable),
-    #[error("Name: {0}")]
-    Name(#[from] NameRecoverable),
-    #[error("Integer: {0}")]
-    Integer(#[from] IntegerRecoverable),
-    #[error("Real: {0}")]
-    Real(#[from] RealRecoverable),
-    #[error("Numeric: {0}")]
-    Numeric(#[from] NumericRecoverable),
-    #[error("Hexadecimal: {0}")]
-    Hexadecimal(#[from] HexadecimalRecoverable),
-    #[error("Literal: {0}")]
-    Literal(#[from] LiteralRecoverable),
-    #[error("String: {0}")]
-    String(#[from] StringRecoverable),
-    #[error("Array: {0}")]
-    Array(#[from] ArrayRecoverable),
-    #[error("Dictionary: {0}")]
-    Dictionary(#[from] DictionaryRecoverable),
-    #[error("Direct Value: {0}")]
-    DirectValue(#[from] DirectValueRecoverable),
-    #[error("Id: {0}")]
-    Id(#[from] IdRecoverable),
-    #[error("Reference: {0}")]
-    Reference(#[from] ReferenceRecoverable),
-    #[error("Indirect Object: {0}")]
-    IndirectObject(#[from] IndirectObjectRecoverable),
-    #[error("Indirect Value: {0}")]
-    IndirectValue(#[from] IndirectValueRecoverable),
-    #[error("Stream: {0}")]
-    Stream(#[from] StreamRecoverable),
-}
-
-// TODO (TEMP)
-#[derive(Debug, Error, PartialEq, Clone)]
-pub enum ParseFailure {
-    // TODO Remove Utf8Error from ParseFailure
-    // Utf8Error should not happen, as ::std::str::from_utf8 is only called
-    // for bytes that are already validated as UTF-8
-    #[error("Utf8Error: Failed to parse as a string slice: {1}. Buffer: {0}")]
-    Utf8Error(String, Utf8Error),
-    #[error("Real: {0}")]
-    Real(#[from] RealFailure),
-    #[error("Hexadecimal: {0}")]
-    Hexadecimal(#[from] HexadecimalFailure),
-    #[error("Literal: {0}")]
-    Literal(#[from] LiteralFailure),
-    #[error("Array: {0}")]
-    Array(#[from] ArrayFailure),
-    #[error("Dictionary: {0}")]
-    Dictionary(#[from] DictionaryFailure),
-    #[error("Indirect Object: {0}")]
-    IndirectObject(#[from] IndirectObjectFailure),
-    #[error("Stream: {0}")]
-    Stream(#[from] StreamFailure),
-    // TODO Refactor if DataTypeErr is only used in ParseFailure
-    #[error("DataType: {0}")]
-    DataType(#[from] DataTypeError<'static>),
-}
-
-impl NewParseErr<'_> {
-    pub fn code(&self) -> &ParseErrorCode {
-        match self {
-            Self::Recoverable(err) => &err.code,
-            Self::Failure(err) => &err.code,
-            Self::Old(_) => unimplemented!(),
-        }
-    }
-}
-
-// TODO(TEMP)
-impl ParseErr {
-    pub fn code(&self) -> &ParseErrorCode {
-        unimplemented!()
-    }
-}
-
-#[macro_export]
-macro_rules! new_parse_failure {
-    ($e:ident, $failure:expr) => {
-        |err| match err {
-            NomErr::Incomplete(_) => unreachable!(
-                "::nom::complete functions do not return the Incomplete error variant."
-            ),
-            NomErr::Error($e) | NomErr::Failure($e) => NewParseErr::Failure($failure.into()),
-        }
-    };
+    // Whole buffer errors
+    #[error("Buffer is too small")]
+    TooSmallBuffer,
+    // Whole object errors
+    #[error("Object type")]
+    ObjectType,
+    #[error("Not found. Error: {}", .0.description())]
+    NotFound(ErrorKind),
+    #[error("Missing data. Error: {}", .0.description())]
+    MissingData(ErrorKind),
+    #[error("Missing closing. Error: {}", .0.description())]
+    MissingClosing(ErrorKind),
+    // Union Errors
+    #[error("Not found")]
+    NotFoundUnion,
+    // Collection Errors
+    // TODO (TEMP) Replace with &'buffer ParseErrorCode<'buffer>
+    #[error("Not found. Error: {0}")]
+    RecNotFound(Box<ParseErrorCode>),
+    #[error("Missing subobject {0}. Error: {1}")]
+    RecMissingSubobject(&'static str, Box<ParseErrorCode>),
+    #[error("Missing key: Error: {0}")]
+    RecMissingKey(&'static str),
+    #[error("Missing value. Key {0}. Error: {1}")]
+    RecMissingValue(Name, Box<ParseErrorCode>),
+    #[error("Missing closing. Error: {0}")]
+    RecMissingClosing(Box<ParseErrorCode>),
+    #[error(
+        "Entry number {} in subsection {} {}. Error: {}",
+        index,
+        first_object_number,
+        entry_count,
+        code
+    )]
+    Entry {
+        index: usize,
+        first_object_number: ObjectNumberOrZero,
+        entry_count: usize,
+        code: Box<ParseErrorCode>,
+    },
+    // TODO Move to NumErrorCode
+    #[error("Object number")]
+    ObjectNumber, // ObjectNumber::new
+    #[error("Generation number")]
+    GenerationNumber, // ascii_to_u16
+    #[error("First object number")]
+    FirstObjectNumber, // ascii_to_u64
+    #[error("Offset")]
+    OffSet, // ascii_to_usize
+    #[error("Next free object number")]
+    NextFree, // ascii_to_u64
+    #[error("Entry type")]
+    EntryType, // f or n
+    #[error("Entry count")]
+    EntryCount, // TODO ascii_to_usize
+    #[error("Parse as i128")]
+    ParseIntError, // ascii_to_i128
+    #[error("Parse as f64")]
+    ParseFloatError, // ascii_to_f64
+    // Errors requiring processing
+    #[error("Invalid trailer dictionary. Error: {0}")]
+    InvalidTrailerDictionary(NewProcessErr),
+    // TODO(TEMP) Refactor into a variant of this enum
+    #[error("Value type. Error: {0}")]
+    ValueType(#[from] DataTypeError<'static>),
 }
 
 #[macro_export]
@@ -211,19 +126,7 @@ macro_rules! parse_recoverable {
             NomErr::Incomplete(_) => unreachable!(
                 "::nom::complete functions do not return the Incomplete error variant."
             ),
-            NomErr::Error($e) | NomErr::Failure($e) => NewParseErr::Recoverable($error),
-        }
-    };
-}
-
-#[macro_export]
-macro_rules! parse_error {
-    ($e:ident, $error:expr) => {
-        |err| match err {
-            NomErr::Incomplete(_) => unreachable!(
-                "::nom::complete functions do not return the Incomplete error variant."
-            ),
-            NomErr::Error($e) | NomErr::Failure($e) => ParseErr::Error($error.into()),
+            NomErr::Error($e) | NomErr::Failure($e) => ParseErr::Recoverable($error),
         }
     };
 }
@@ -231,22 +134,33 @@ macro_rules! parse_error {
 mod convert {
     use super::*;
 
-    // TODO(TEMP)
-    impl<'buffer> From<ParseFailure> for NewParseErr<'buffer> {
-        fn from(err: ParseFailure) -> Self {
-            NewParseErr::Old(err.into())
+    impl<'buffer> ParseErr<'buffer> {
+        pub fn buffer(&self) -> &'buffer [Byte] {
+            match self {
+                Self::Recoverable(err) => err.buffer,
+                Self::Failure(err) => err.buffer,
+            }
         }
     }
 
-    impl<'buffer> From<NewParseFailure<'buffer>> for NewParseErr<'buffer> {
-        fn from(err: NewParseFailure<'buffer>) -> Self {
-            NewParseErr::Failure(err)
+    impl ParseErr<'_> {
+        pub fn code(self) -> ParseErrorCode {
+            match self {
+                Self::Recoverable(err) => err.code,
+                Self::Failure(err) => err.code,
+            }
         }
     }
 
-    impl<'buffer> From<NewParseRecoverable<'buffer>> for NewParseErr<'buffer> {
-        fn from(err: NewParseRecoverable<'buffer>) -> Self {
-            NewParseErr::Recoverable(err)
+    impl<'buffer> From<ParseFailure<'buffer>> for ParseErr<'buffer> {
+        fn from(err: ParseFailure<'buffer>) -> Self {
+            ParseErr::Failure(err)
+        }
+    }
+
+    impl<'buffer> From<ParseRecoverable<'buffer>> for ParseErr<'buffer> {
+        fn from(err: ParseRecoverable<'buffer>) -> Self {
+            ParseErr::Recoverable(err)
         }
     }
 }

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -2,8 +2,6 @@ pub(crate) mod character_set;
 pub(crate) mod error;
 pub(crate) mod num;
 
-use self::error::NewParseErr;
-use self::error::NewParseResult;
 use self::error::ParseErr;
 use self::error::ParseResult;
 use crate::Byte;
@@ -26,8 +24,8 @@ pub(crate) const KW_TRAILER: &str = "trailer";
 pub(crate) const KW_TRUE: &str = "true";
 pub(crate) const KW_XREF: &str = "xref";
 
-pub(crate) trait Parser {
-    fn parse(buffer: &[Byte]) -> ParseResult<(&[Byte], Self)>
+pub(crate) trait Parser<'buffer> {
+    fn parse(buffer: &'buffer [Byte]) -> ParseResult<'buffer, (&[Byte], Self)>
     where
         Self: Sized;
 
@@ -37,7 +35,7 @@ pub(crate) trait Parser {
     /// recovery
     /// - None: if the parser returned another error, which could be recovered
     /// by another parser
-    fn parse_semi_quiet<O>(buffer: &[Byte]) -> Option<ParseResult<(&[Byte], O)>>
+    fn parse_suppress_recoverable<O>(buffer: &'buffer [Byte]) -> Option<ParseResult<(&[Byte], O)>>
     where
         Self: Sized,
         O: From<Self>,
@@ -50,62 +48,21 @@ pub(crate) trait Parser {
         }
     }
 }
-pub(crate) trait NewParser<'buffer> {
-    fn parse(buffer: &'buffer [Byte]) -> NewParseResult<'buffer, (&[Byte], Self)>
-    where
-        Self: Sized;
-
-    /// Try to parse the buffer and return an option:
-    /// - Some(Ok(_)): if the buffer was parsed successfully
-    /// - Some(Err(ParseErr::Failure(_))): if the parser failed with no possible
-    /// recovery
-    /// - None: if the parser returned another error, which could be recovered
-    /// by another parser
-    fn parse_semi_quiet<O>(buffer: &'buffer [Byte]) -> Option<NewParseResult<(&[Byte], O)>>
-    where
-        Self: Sized,
-        O: From<Self>,
-    {
-        let result = Self::parse(buffer);
-        match result {
-            Ok((buffer, object)) => Some(Ok((buffer, object.into()))),
-            Err(NewParseErr::Failure(err)) => Some(Err(NewParseErr::Failure(err))),
-            _ => None,
-        }
-    }
-}
 
 mod tests {
     #[macro_export]
-    macro_rules! new_parse_assert_eq {
-        ($buffer:expr, $expected_parsed:expr, $expected_remaining:expr) => {
-            assert_eq!(
-                NewParser::parse($buffer).unwrap(),
-                ($expected_remaining, $expected_parsed)
-            );
-        };
-        // The two patterns differ only in the trailing comma
-        ($buffer:expr, $expected_parsed:expr, $expected_remaining:expr,) => {
-            assert_eq!(
-                NewParser::parse($buffer).unwrap(),
-                ($expected_remaining, $expected_parsed)
-            );
-        };
-    }
-
-    #[macro_export]
     macro_rules! parse_assert_eq {
-        ($buffer:expr, $expected_parsed:expr, $expected_remaining:expr) => {
+        ($buffer:expr, $expected_parsed:expr, $expected_remains:expr) => {
             assert_eq!(
                 Parser::parse($buffer).unwrap(),
-                ($expected_remaining, $expected_parsed)
+                ($expected_remains, $expected_parsed)
             );
         };
         // The two patterns differ only in the trailing comma
-        ($buffer:expr, $expected_parsed:expr, $expected_remaining:expr,) => {
+        ($buffer:expr, $expected_parsed:expr, $expected_remains:expr,) => {
             assert_eq!(
                 Parser::parse($buffer).unwrap(),
-                ($expected_remaining, $expected_parsed)
+                ($expected_remains, $expected_parsed)
             );
         };
     }

--- a/src/parse/num.rs
+++ b/src/parse/num.rs
@@ -1,63 +1,76 @@
 use crate::Byte;
 
-// TODO Refactor the repetitive functions below
+// TODO Refactor the repetitive functions below using num-traits
+
+pub(crate) fn bytes_to_u64(bytes: &[Byte]) -> Option<u64> {
+    bytes.iter().try_fold(0u64, |number, byte| {
+        number
+            .checked_shl(8)
+            .and_then(|number| number.checked_add(*byte as u64))
+    })
+}
 
 pub(crate) fn ascii_to_u16(bytes: &[Byte]) -> Option<u16> {
-    let mut number = Some(0u16);
-    for &byte in bytes {
+    bytes.iter().try_fold(0u16, |number, &byte| {
         if let b'0'..=b'9' = byte {
-            let digit = byte - b'0';
-            number = number
-                .and_then(|number| number.checked_mul(10))
-                .and_then(|number| number.checked_add(digit as u16));
+            number
+                .checked_mul(10)
+                .and_then(|number| number.checked_add((byte - b'0') as u16))
         } else {
-            return None;
+            None
         }
-    }
-    number
+    })
 }
 
 pub(crate) fn ascii_to_u64(bytes: &[Byte]) -> Option<u64> {
-    let mut number = Some(0u64);
-    for &byte in bytes {
+    bytes.iter().try_fold(0u64, |number, &byte| {
         if let b'0'..=b'9' = byte {
-            let digit = byte - b'0';
-            number = number
-                .and_then(|number| number.checked_mul(10))
-                .and_then(|number| number.checked_add(digit as u64));
+            number
+                .checked_mul(10)
+                .and_then(|number| number.checked_add((byte - b'0') as u64))
         } else {
-            return None;
+            None
         }
-    }
-    number
+    })
+}
+
+pub(crate) fn ascii_to_usize(bytes: &[Byte]) -> Option<usize> {
+    bytes.iter().try_fold(0usize, |number, &byte| {
+        if let b'0'..=b'9' = byte {
+            number
+                .checked_mul(10)
+                .and_then(|number| number.checked_add((byte - b'0') as usize))
+        } else {
+            None
+        }
+    })
 }
 
 pub(crate) fn ascii_to_i128(bytes: &[Byte]) -> Option<i128> {
-    let mut number = Some(0i128);
     let negative_sign = bytes.first().and_then(|&byte| match byte {
         b'-' => Some(true),
         b'+' => Some(false),
         _ => None,
     });
 
-    for &byte in bytes.iter().skip(negative_sign.is_some() as usize) {
-        match byte {
-            b'0'..=b'9' => {
-                let digit = byte - b'0';
+    bytes
+        .iter()
+        .skip(negative_sign.is_some() as usize)
+        .try_fold(0i128, |number, &byte| {
+            if let b'0'..=b'9' = byte {
                 if let Some(true) = negative_sign {
-                    number = number
-                        .and_then(|number| number.checked_mul(10))
-                        .and_then(|number| number.checked_sub(digit as i128));
+                    number
+                        .checked_mul(10)
+                        .and_then(|number| number.checked_sub((byte - b'0') as i128))
                 } else {
-                    number = number
-                        .and_then(|number| number.checked_mul(10))
-                        .and_then(|number| number.checked_add(digit as i128));
+                    number
+                        .checked_mul(10)
+                        .and_then(|number| number.checked_add((byte - b'0') as i128))
                 }
+            } else {
+                None
             }
-            _ => return None,
-        }
-    }
-    number
+        })
 }
 
 // ascii_to_f64 is more restrictive than str::parse::<f64> as exponent
@@ -115,16 +128,6 @@ pub(crate) fn ascii_to_f64(bytes: &[Byte]) -> Option<f64> {
     } else {
         Some(integer + fraction)
     }
-}
-
-pub(crate) fn bytes_to_u64(bytes: &[Byte]) -> Option<u64> {
-    let mut number = Some(0u64);
-    for &byte in bytes {
-        number = number
-            .and_then(|number| number.checked_shl(8))
-            .and_then(|number| number.checked_add(byte as u64));
-    }
-    number
 }
 
 pub(crate) fn hex_val(byte: Byte) -> Option<Byte> {

--- a/src/pdf/error.rs
+++ b/src/pdf/error.rs
@@ -1,0 +1,87 @@
+use ::std::fmt::Display;
+use ::std::fmt::Formatter;
+use ::std::fmt::Result as FmtResult;
+use ::std::io::ErrorKind;
+use ::std::num::TryFromIntError;
+use ::thiserror::Error;
+
+use super::*;
+use crate::object::indirect::id::Id;
+use crate::parse::error::ParseErr;
+use crate::process::error::ProcessErr;
+use crate::Offset;
+
+pub type PdfResult<'path, T> = Result<T, PdfErr<'path>>;
+
+// Include the path in all PdfErr variants to simplify debugging
+#[derive(Debug, Error, PartialEq, Clone)]
+pub enum PdfErr<'path> {
+    #[error("Parse. File: {0}. Error: {1}")]
+    Parse(&'path Path, ParseErr),
+    #[error("Process. File: {0}. Error: {1}")]
+    Process(&'path Path, ProcessErr),
+    #[error("Empty cross-reference table. File: {0}")]
+    EmptyPreTable(&'path Path),
+    // ::std::io::Error as IoError; does not implement PartialEq or Clone,
+    // and it's mor convenient to use ::std::io::ErrorKind here instead
+    #[error("Open. File: {0}. Error kind: {1}")]
+    OpenFile(&'path Path, ErrorKind),
+    #[error("Seek. File: {0}. Error kind: {1}")]
+    Seek(&'path Path, ErrorKind),
+    #[error("Read. File: {0}. Error kind: {1}")]
+    ReadFile(&'path Path, ErrorKind),
+}
+
+#[derive(Debug, Error, PartialEq, Clone)]
+pub struct PdfRecoverable<'path> {
+    path: &'path Path,
+    errors: Vec<ObjectRecoverable>,
+}
+
+impl<'path> Display for PdfRecoverable<'path> {
+    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+        writeln!(
+            f,
+            "Combined errors. File: {}. Number of errors: {}",
+            self.path.display(),
+            self.errors.len()
+        )?;
+        for err in &self.errors {
+            writeln!(f, "File: {}. Error {}", self.path.display(), err)?;
+        }
+        Ok(())
+    }
+}
+
+// This error variant is always included in the PdfRecoverable, and
+// there is no need to include the path here.
+#[derive(Debug, Error, PartialEq, Clone)]
+pub enum ObjectRecoverable {
+    #[error("Parse. Id: {0}. Offset {1}. Error: {2}")]
+    Parse(Id, u64, ParseErr),
+    #[error("Convert offset to usize. Id: {0}. Offset: {1}. Error: {2}")]
+    OffsetAsUsize(Id, Offset, TryFromIntError),
+    #[error("Mismatched id: {0} != {1}")]
+    MismatchedId(Id, Id),
+}
+
+mod convert {
+
+    use ::std::ops::Deref;
+
+    use super::*;
+
+    impl<'path> PdfRecoverable<'path> {
+        pub fn new(path: &'path Path, errors: Vec<ObjectRecoverable>) -> Self {
+            Self { path, errors }
+        }
+    }
+
+    impl<'path> Deref for PdfRecoverable<'path> {
+        type Target = Vec<ObjectRecoverable>;
+
+        fn deref(&self) -> &Self::Target {
+            &self.errors
+        }
+    }
+}

--- a/src/pdf/mod.rs
+++ b/src/pdf/mod.rs
@@ -52,8 +52,8 @@ pub struct Pdf<'path> {
     errors: PdfRecoverable<'path>,
 }
 
-impl<'path> Pdf<'path> {
-    pub fn status(&'path self) -> Result<(), &PdfRecoverable<'path>> {
+impl Pdf<'_> {
+    pub fn status(&self) -> Result<(), &PdfRecoverable> {
         if self.errors.is_empty() {
             Ok(())
         } else {
@@ -79,6 +79,7 @@ mod process {
     use super::error::PdfResult;
     use super::*;
     use crate::object::indirect::object::IndirectObject;
+    use crate::parse::NewParser;
     use crate::parse::Parser;
     use crate::xref::pretable::PreTable;
     use crate::xref::ToTable;

--- a/src/pdf/mod.rs
+++ b/src/pdf/mod.rs
@@ -1,10 +1,12 @@
+pub(crate) mod error;
+
 use ::std::collections::HashMap;
 use ::std::fs::File;
 use ::std::io::BufReader;
-use ::std::path::PathBuf;
+use ::std::path::Path;
 
-use self::error::PdfError;
-use self::error::PdfResult;
+use self::error::PdfErr;
+use self::error::PdfRecoverable;
 use crate::object::indirect::id::Id;
 use crate::object::indirect::IndirectValue;
 use crate::xref::increment::trailer::Trailer;
@@ -21,16 +23,16 @@ pub struct Span {
 }
 
 #[derive(Debug)]
-pub struct PdfBuilder {
-    path: PathBuf,
+pub struct PdfBuilder<'path> {
+    path: &'path Path,
     buffer: Vec<Byte>,
 }
 
 /// REFERENCE: [7.5.1 General, p53]
 #[derive(Debug)]
-pub struct Pdf {
-    path: PathBuf,
-    buffer: Vec<Byte>,
+pub struct Pdf<'path> {
+    path: &'path Path,
+    buffer: &'path [Byte],
     /// • The trailer
     trailer: Trailer,
     /// • The cross-reference table
@@ -47,23 +49,23 @@ pub struct Pdf {
     // - Compressed objects
     // - comments: Vec<Comment>,
     // - spans: BTreeSet<Span>,
-    errors: Vec<PdfError>,
+    errors: PdfRecoverable<'path>,
 }
 
-impl Pdf {
-    pub fn status(&self) -> PdfResult<()> {
+impl<'path> Pdf<'path> {
+    pub fn status(&'path self) -> Result<(), &PdfRecoverable<'path>> {
         if self.errors.is_empty() {
             Ok(())
         } else {
-            Err(PdfError::Multiple(self.errors.clone()))
+            Err(&self.errors)
         }
     }
 
     // TODO A temporary debugging method
     pub fn summary(&self) -> String {
         format!(
-            "PDF: {:?} # Objects: {:?} # Errors: {:?}",
-            self.path,
+            "PDF: {} # Objects: {} # Errors: {}",
+            self.path.display(),
             self.objects_in_use.len(),
             self.errors.len()
         )
@@ -72,7 +74,8 @@ impl Pdf {
 
 mod process {
 
-    use super::error::PdfError;
+    use super::error::ObjectRecoverable;
+    use super::error::PdfErr;
     use super::error::PdfResult;
     use super::*;
     use crate::object::indirect::object::IndirectObject;
@@ -80,35 +83,35 @@ mod process {
     use crate::xref::pretable::PreTable;
     use crate::xref::ToTable;
 
-    impl PdfBuilder {
-        fn get_trailer(&self, pretable: &PreTable) -> PdfResult<Trailer> {
+    impl<'path> PdfBuilder<'path> {
+        fn get_trailer(&'path self, pretable: &PreTable) -> PdfResult<Trailer> {
             if let Some(increment) = pretable.back() {
                 Ok(increment.trailer().clone())
             } else {
-                Err(PdfError::EmptyPreTable(self.path.clone()))
+                Err(PdfErr::EmptyPreTable(self.path))
             }
         }
 
         fn parse_objects_in_use(
-            &mut self,
+            &self,
             table: &Table,
-        ) -> PdfResult<(ObjectsInUse, Vec<PdfError>)> {
+            errors: &mut Vec<ObjectRecoverable>,
+        ) -> PdfResult<ObjectsInUse> {
             // At this point, we should not immediately fail. Instead, we
             // collect all errors and report them at the end.
-            let mut errors = Vec::default();
             let mut objects = HashMap::default();
             for (offset, id) in table.in_use.iter() {
                 let start = match usize::try_from(*offset) {
                     Ok(offset) => offset,
                     Err(err) => {
-                        errors.push(PdfError::OffsetAsUsize(*id, *offset, err));
+                        errors.push(ObjectRecoverable::OffsetAsUsize(*id, *offset, err));
                         continue;
                     }
                 };
                 let (remaining, object) = match IndirectObject::parse(&self.buffer[start..]) {
                     Ok((remaining, object)) => (remaining, object),
                     Err(err) => {
-                        errors.push(PdfError::Object(*id, *offset, err));
+                        errors.push(ObjectRecoverable::Parse(*id, *offset, err));
                         continue;
                     }
                 };
@@ -119,7 +122,7 @@ mod process {
                     value,
                 } = object;
                 if parsed_id != *id {
-                    errors.push(PdfError::MismatchedId(*id, parsed_id));
+                    errors.push(ObjectRecoverable::MismatchedId(*id, parsed_id));
                     // continue;
                 }
                 let span = Span {
@@ -130,21 +133,26 @@ mod process {
                 objects.insert(*id, (value, span));
             }
 
-            Ok((objects, errors))
+            Ok(objects)
         }
 
-        pub fn build(mut self) -> PdfResult<Pdf> {
+        pub fn build(&'path self) -> PdfResult<'path, Pdf<'path>> {
             // REFERENCE: [7.5.1 General, p54]
             // Apart from linearised PDFs, files should be read from the end
             // using the trailer and cross-reference table.
-            let (_, pretable) = PreTable::parse(&self.buffer)?;
+            let (_, pretable) =
+                PreTable::parse(&self.buffer).map_err(|err| PdfErr::Parse(self.path, err))?;
             let trailer = self.get_trailer(&pretable)?;
-            let table = pretable.to_table()?;
-            let (objects_in_use, errors) = self.parse_objects_in_use(&table)?;
+            let table = pretable
+                .to_table()
+                .map_err(|err| PdfErr::Process(self.path, err))?;
+            let mut errors = Vec::default();
+            let objects_in_use = self.parse_objects_in_use(&table, &mut errors)?;
+            let errors = PdfRecoverable::new(self.path, errors);
 
             Ok(Pdf {
                 path: self.path,
-                buffer: self.buffer,
+                buffer: &self.buffer,
                 trailer,
                 table,
                 objects_in_use,
@@ -155,6 +163,7 @@ mod process {
 }
 
 mod convert {
+
     use ::std::io::Read;
     use ::std::io::Seek;
     use ::std::io::SeekFrom;
@@ -162,65 +171,19 @@ mod convert {
     use super::error::PdfResult;
     use super::*;
 
-    impl PdfBuilder {
-        pub fn new(path: impl Into<PathBuf>) -> PdfResult<Self> {
-            let path = path.into();
-            let file = File::open(&path).map_err(|err| {
-                PdfError::Io(format!("Failed to open {}: {}", path.display(), err))
-            })?;
+    impl<'path> PdfBuilder<'path> {
+        pub fn new(path: &'path Path) -> PdfResult<Self> {
+            let file = File::open(path).map_err(|err| PdfErr::OpenFile(path, err.kind()))?;
             let mut reader = BufReader::new(file);
-            reader.seek(SeekFrom::Start(0)).map_err(|err| {
-                PdfError::Io(format!(
-                    "Failed to seek the start of {}: {}",
-                    path.display(),
-                    err
-                ))
-            })?;
+            reader
+                .seek(SeekFrom::Start(0))
+                .map_err(|err| PdfErr::Seek(path, err.kind()))?;
             let mut buffer = Vec::default();
-            reader.read_to_end(&mut buffer).map_err(|err| {
-                PdfError::Io(format!("Failed to read {}: {}", path.display(), err))
-            })?;
+            reader
+                .read_to_end(&mut buffer)
+                .map_err(|err| PdfErr::ReadFile(path, err.kind()))?;
             Ok(Self { path, buffer })
         }
-    }
-}
-
-pub(crate) mod error {
-    use ::std::num::TryFromIntError;
-    use ::std::path::PathBuf;
-    use ::thiserror::Error;
-
-    use crate::object::indirect::id::Id;
-    use crate::parse::error::ParseErr;
-    use crate::process::error::ProcessErr;
-    use crate::Offset;
-
-    pub type PdfResult<T> = Result<T, PdfError>;
-
-    #[derive(Debug, Error, PartialEq, Clone)]
-    pub enum PdfError {
-        // TODO Split into different variants
-        #[error("IoError: {0}")]
-        Io(String),
-
-        #[error("Parse {0}")]
-        Parse(#[from] ParseErr),
-        #[error("Process {0}")]
-        Process(#[from] ProcessErr),
-
-        #[error("Failed to convert offset {1} for id {0}: {2}")]
-        OffsetAsUsize(Id, Offset, TryFromIntError),
-        #[error("Empty cross-reference table in {0}")]
-        EmptyPreTable(PathBuf),
-        #[error("Reached end of file while parsing indirect object {0} at offset {1}")]
-        EndOfFile(Id, Offset),
-        #[error("Mismatched id: {0} != {1}")]
-        MismatchedId(Id, Id),
-        #[error("Parse: {0} at offset {1}: {2}")]
-        Object(Id, u64, ParseErr),
-        // TODO Implement Display for a wrapper around Vec<PdfError>
-        #[error("Multiple errors: {0:?}")]
-        Multiple(Vec<PdfError>),
     }
 }
 

--- a/src/process/encoding.rs
+++ b/src/process/encoding.rs
@@ -33,7 +33,7 @@ impl Decoder for Encoding {
             }
             Self::PdfDoc => {
                 todo!("Implement Encoding::decode for PdfDoc")
-                // Ok(self.0.iter().map(|&b| b as char).collect())
+                // Ok(self.0.iter().map(|&b| char::from(b)).collect())
             }
             Self::Utf8 => {
                 // REFERENCE: [7.9.2.2.1 General, p116]

--- a/src/process/error.rs
+++ b/src/process/error.rs
@@ -23,9 +23,8 @@ pub(crate) type NewProcessResult<T> = Result<T, NewProcessErr>;
 pub(crate) type ProcessResult<T> = Result<T, ProcessErr>;
 
 #[derive(Debug, Error, PartialEq, Clone)]
-
 pub enum NewProcessErr {
-    // TODO (TEMP)
+    // TODO (TEMP) Remove this error variant after refactoring ProcessErr
     #[error("Old: {0}")]
     Old(#[from] ProcessErr),
     //
@@ -33,7 +32,6 @@ pub enum NewProcessErr {
     DataType(#[from] DataTypeError<'static>),
     #[error("MissingEntry: {0}")]
     MissingEntry(#[from] MissingEntryError),
-    //
     #[error("Entry: {0}")]
     Entry(#[from] EntryError),
     #[error("XRefStream: {0}")]
@@ -50,7 +48,7 @@ pub enum ProcessErr {
     Encoding(#[from] EncodingError),
     #[error("Escape: {0}")]
     Escape(#[from] EscapeError),
-    // TODO (TEMP)
+    // TODO (TEMP) Remove this error variant after refactoring escape and encoding
     #[error("Utf8: {0}")]
     Utf8(#[from] Utf8Error),
     // Filter errors

--- a/src/process/escape.rs
+++ b/src/process/escape.rs
@@ -1,6 +1,5 @@
 pub(crate) mod error {
     use ::std::num::ParseIntError;
-    use ::std::str::Utf8Error;
     use ::thiserror::Error;
 
     use crate::object::direct::name::error::NameEscape;
@@ -9,8 +8,6 @@ pub(crate) mod error {
     pub enum EscapeError {
         #[error(transparent)]
         Name(#[from] NameEscape),
-        #[error("Utf8Error: {0}")]
-        Utf8Error(#[from] Utf8Error),
         #[error("ParseIntError: {0}")]
         ParseIntError(#[from] ParseIntError),
     }

--- a/src/process/filter/ascii_85.rs
+++ b/src/process/filter/ascii_85.rs
@@ -21,19 +21,15 @@ impl Filter for A85 {
             }
             let mut value = 0u32;
             for &byte in prev.iter() {
-                value =
-                    (value << 8)
-                        .checked_add(byte as u32)
-                        .ok_or(ASCII85Error::ValueTooLarge(
-                            stringify!(Byte),
-                            debug_bytes(&prev),
-                        ))?;
+                value = (value << 8).checked_add(u32::from(byte)).ok_or(
+                    ASCII85Error::ValueTooLarge(stringify!(Byte), debug_bytes(&prev)),
+                )?;
             }
             if value == 0 {
                 encoded.push(b'z');
             } else {
-                for i in (0..5).rev() {
-                    encoded.push((value / 85u32.pow(i as u32) % 85 + b'!' as u32) as Byte);
+                for i in (0u32..5).rev() {
+                    encoded.push((value / 85u32.pow(i) % 85 + u32::from(b'!')) as Byte);
                 }
             }
             prev.clear();
@@ -41,16 +37,12 @@ impl Filter for A85 {
         if !prev.is_empty() {
             let mut value = 0u32;
             for &byte in prev.iter().chain(&vec![0; 4 - prev.len()]) {
-                value =
-                    (value << 8)
-                        .checked_add(byte as u32)
-                        .ok_or(ASCII85Error::ValueTooLarge(
-                            stringify!(Byte),
-                            debug_bytes(&prev),
-                        ))?;
+                value = (value << 8).checked_add(u32::from(byte)).ok_or(
+                    ASCII85Error::ValueTooLarge(stringify!(Byte), debug_bytes(&prev)),
+                )?;
             }
-            for i in (0..5).rev().take(prev.len() + 1) {
-                encoded.push((value / 85u32.pow(i as u32) % 85 + b'!' as u32) as Byte);
+            for i in (0u32..5).rev().take(prev.len() + 1) {
+                encoded.push((value / 85u32.pow(i) % 85 + u32::from(b'!')) as Byte);
             }
         }
         // Add the EOD marker
@@ -70,14 +62,14 @@ impl Filter for A85 {
                 continue;
             }
             if eod {
-                return Err(ASCII85Error::AfterEod(byte as char).into());
+                return Err(ASCII85Error::AfterEod(char::from(byte)).into());
             }
             if tilde {
                 if byte == b'>' {
                     eod = true;
                     continue;
                 } else {
-                    return Err(ASCII85Error::CorruptEod(byte as char).into());
+                    return Err(ASCII85Error::CorruptEod(char::from(byte)).into());
                 }
             }
             if byte == b'~' {
@@ -93,7 +85,7 @@ impl Filter for A85 {
                 }
             }
             if !(b'!'..=b'u').contains(&byte) {
-                return Err(ASCII85Error::InvalidBase85Digit(byte as char).into());
+                return Err(ASCII85Error::InvalidBase85Digit(char::from(byte)).into());
             }
             prev.push(byte);
             if prev.len() < 5 {
@@ -105,7 +97,7 @@ impl Filter for A85 {
                 value = value
                     .checked_mul(85)
                     .ok_or(ASCII85Error::ValueTooLarge("Base85", debug_bytes(&prev)))?
-                    .checked_add((byte - b'!') as u32)
+                    .checked_add(u32::from(byte - b'!'))
                     .ok_or(ASCII85Error::ValueTooLarge("Base85", debug_bytes(&prev)))?;
             }
             defiltered.extend_from_slice(&value.to_be_bytes());
@@ -121,7 +113,7 @@ impl Filter for A85 {
                 value = value
                     .checked_mul(85)
                     .ok_or(ASCII85Error::ValueTooLarge("Base85", debug_bytes(&prev)))?
-                    .checked_add((byte - b'!') as u32)
+                    .checked_add(u32::from(byte - b'!'))
                     .ok_or(ASCII85Error::ValueTooLarge("Base85", debug_bytes(&prev)))?;
             }
             defiltered.extend_from_slice(&value.to_be_bytes()[..prev.len() - 1]);
@@ -134,6 +126,7 @@ impl Filter for A85 {
 pub(in crate::process) mod error {
     use ::thiserror::Error;
 
+    // FIXME (TEMP) Restrict the use of debug_bytes to error display
     #[derive(Debug, Error, PartialEq, Clone)]
     pub enum ASCII85Error {
         #[error("Invalid ASCII base-85 digit: {0}")]

--- a/src/process/filter/ascii_hex.rs
+++ b/src/process/filter/ascii_hex.rs
@@ -46,7 +46,7 @@ impl Filter for AHx {
                 continue;
             }
             if eod {
-                return Err(ASCIIHexError::AfterEod(byte as char).into());
+                return Err(ASCIIHexError::AfterEod(char::from(byte)).into());
             }
             if byte == b'>' {
                 eod = true;
@@ -54,8 +54,8 @@ impl Filter for AHx {
             }
             if let Some(a) = prev {
                 defiltered.push(
-                    hex_val(a).ok_or(ASCIIHexError::InvalidHexDigit(a as char))? << 4
-                        | hex_val(byte).ok_or(ASCIIHexError::InvalidHexDigit(byte as char))?,
+                    hex_val(a).ok_or(ASCIIHexError::InvalidHexDigit(char::from(a)))? << 4
+                        | hex_val(byte).ok_or(ASCIIHexError::InvalidHexDigit(char::from(byte)))?,
                 );
 
                 prev = None;
@@ -64,7 +64,7 @@ impl Filter for AHx {
             }
         }
         if let Some(a) = prev {
-            defiltered.push(hex_val(a).ok_or(ASCIIHexError::AfterEod(a as char))? << 4);
+            defiltered.push(hex_val(a).ok_or(ASCIIHexError::AfterEod(char::from(a)))? << 4);
         }
 
         Ok(defiltered)

--- a/src/process/filter/flate.rs
+++ b/src/process/filter/flate.rs
@@ -26,7 +26,7 @@ impl Filter for Fl {
             ZlibEncoder::new(bytes.as_ref(), Compression::default());
         filter
             .read_to_end(&mut filtered)
-            .map_err(|err| FlateError::Filter(err.to_string()))?;
+            .map_err(|err| FlateError::Filter(err.to_string()))?; // TODO (TEMP) Avoid to_string
 
         Ok(filtered)
     }
@@ -38,7 +38,7 @@ impl Filter for Fl {
         let mut defilter = ZlibDecoder::new(bytes.as_ref());
         defilter
             .read_to_end(&mut defiltered)
-            .map_err(|err| FlateError::Defilter(err.to_string()))?;
+            .map_err(|err| FlateError::Defilter(err.to_string()))?; // TODO (TEMP) Avoid to_string
 
         let defiltered = self.predictor.defilter(defiltered)?;
         Ok(defiltered)
@@ -80,7 +80,6 @@ mod tests {
     // use super::Fl;
     // use crate::assert_err_eq;
     // use crate::object::indirect::stream::Stream;
-    // use crate::parse::Parser;
     // use crate::process::filter::flate::error::FlateError;
     use crate::process::filter::tests::lax_stream_defilter_filter;
 

--- a/src/process/filter/predictor/columns.rs
+++ b/src/process/filter/predictor/columns.rs
@@ -28,11 +28,13 @@ mod convert {
         type Error = ProcessErr;
 
         fn try_from(value: &DirectValue) -> Result<Self, Self::Error> {
+            // TODO Replace with `as_usize`
             if let DirectValue::Numeric(Numeric::Integer(value)) = value {
                 let value = usize::try_from(**value)
-                    .map_err(|_| PredictorError::Unsupported(stringify!(Columns), **value))?;
+                    .map_err(|_| PredictorError::Unsupported(stringify!(Columns), **value))?; // TODO (TEMP) Avoid overriding the error
                 Ok(Self(value))
             } else {
+                // TODO (TEMP) Refactor to avoid cloning
                 Err(PredictorError::DataType(stringify!(Columns), value.clone()).into())
             }
         }

--- a/src/process/filter/predictor/png.rs
+++ b/src/process/filter/predictor/png.rs
@@ -277,7 +277,8 @@ mod process {
         for x in 0..scanline.len() {
             let left = scanline.get(x - bytes_per_pixel).unwrap_or(&0);
             let up = prior_scanline.get(x).unwrap_or(&0);
-            diff[x + 1] = scanline[x].wrapping_sub(((*left as u16 + *up as u16) >> 1) as Byte);
+            diff[x + 1] =
+                scanline[x].wrapping_sub(((u16::from(*left) + u16::from(*up)) >> 1) as Byte);
         }
         prior_scanline.copy_from_slice(scanline);
     }
@@ -294,7 +295,8 @@ mod process {
         for x in 0..scanline.len() {
             let left = scanline.get(x - bytes_per_pixel).unwrap_or(&0);
             let up = prior_scanline.get(x).unwrap_or(&0);
-            scanline[x] = diff[x + 1].wrapping_add(((*up as u16 + *left as u16) >> 1) as Byte);
+            scanline[x] =
+                diff[x + 1].wrapping_add(((u16::from(*up) + u16::from(*left)) >> 1) as Byte);
         }
         prior_scanline.copy_from_slice(scanline);
     }
@@ -338,10 +340,10 @@ mod process {
     /// REFERENCE: [[https://www.w3.org/TR/PNG-Filters.html] 66.6. Filter type
     /// 4: Paeth]
     fn paeth_predictor(left: Byte, up: Byte, up_left: Byte) -> Byte {
-        let p = left as i16 + up as i16 - up_left as i16;
-        let p_left = (p - left as i16).abs();
-        let p_up = (p - up as i16).abs();
-        let p_up_left = (p - up_left as i16).abs();
+        let p = i16::from(left) + i16::from(up) - i16::from(up_left);
+        let p_left = (p - i16::from(left)).abs();
+        let p_up = (p - i16::from(up)).abs();
+        let p_up_left = (p - i16::from(up_left)).abs();
         if p_left <= p_up && p_left <= p_up_left {
             left
         } else if p_up <= p_up_left {

--- a/src/process/filter/predictor/tiff.rs
+++ b/src/process/filter/predictor/tiff.rs
@@ -95,7 +95,7 @@ struct BitsReader<'a> {
     location: usize,
 }
 
-impl<'a> BitsReader<'a> {
+impl BitsReader<'_> {
     fn next_bits(&mut self) -> ProcessResult<Option<Byte>> {
         let byte_location = self.location / 8;
         let bit_location = self.location % 8;
@@ -183,7 +183,7 @@ struct BitsWriter<'a> {
     bit_location: usize,
 }
 
-impl<'a> BitsWriter<'a> {
+impl BitsWriter<'_> {
     fn write_component(&mut self, component: Byte) -> ProcessResult<()> {
         if self.bit_location + *self.parms.bits_per_component > 8 {
             return Err(TiffError::BitsOutOfBound(

--- a/src/process/filter/predictor/tiff.rs
+++ b/src/process/filter/predictor/tiff.rs
@@ -27,7 +27,7 @@ impl Filter for Tiff {
         // REFERENCE: [[TIFF 6.0 Specification] Section 14: Differencing
         // Predictor, p64]
         while let Some(row) = bit_reader.next_row()? {
-            let mut prev_colors = vec![0; self.parms.colors as usize];
+            let mut prev_colors = vec![0; *self.parms.colors];
             for colors in row.into_iter() {
                 for (prev_component, component) in prev_colors.iter().zip(colors.iter()) {
                     if prev_colors.len() != colors.len() {
@@ -62,7 +62,7 @@ impl Filter for Tiff {
         let mut bit_writer = BitsWriter::new(&mut defiltered, self.parms);
 
         while let Some(row) = bit_reader.next_row()? {
-            let mut prev_colors = vec![0; self.parms.colors as usize];
+            let mut prev_colors = vec![0; *self.parms.colors];
             for diffs in row.into_iter() {
                 let mut colors = Vec::with_capacity(diffs.len());
                 for (prev_component, diff) in prev_colors.iter().zip(diffs.iter()) {
@@ -163,8 +163,8 @@ impl BitsReader<'_> {
         if self.location % 8 != 0 {
             let padding = 8 - self.location % 8;
             if let Some(byte) = self.bytes.get(self.location / 8) {
-                let remaining = byte & ((1 << padding) - 1);
-                if remaining != 0 {
+                let remains = byte & ((1 << padding) - 1);
+                if remains != 0 {
                     return Err(TiffError::RowMissingPadding(padding, *byte).into());
                 }
             }

--- a/src/xref/increment/mod.rs
+++ b/src/xref/increment/mod.rs
@@ -6,13 +6,13 @@ use ::std::fmt::Display;
 use ::std::fmt::Formatter;
 use ::std::fmt::Result as FmtResult;
 
-use self::error::IncrementRecoverable;
 use self::section::Section;
 use self::stream::XRefStream;
-use crate::fmt::debug_bytes;
-use crate::parse::error::ParseErr;
-use crate::parse::error::ParseResult;
-use crate::parse::Parser;
+use crate::parse::error::NewParseErr;
+use crate::parse::error::NewParseRecoverable;
+use crate::parse::error::NewParseResult;
+use crate::parse::error::ParseErrorCode;
+use crate::parse::NewParser;
 use crate::Byte;
 
 /// REFERENCE: [7.5.4 Cross-reference table, p55]
@@ -31,26 +31,28 @@ impl Display for Increment {
     }
 }
 
-impl Parser for Increment {
-    fn parse(buffer: &[Byte]) -> ParseResult<(&[Byte], Self)> {
+impl NewParser<'_> for Increment {
+    fn parse(buffer: &[Byte]) -> NewParseResult<(&[Byte], Self)> {
         Section::parse_semi_quiet::<Self>(buffer)
             .or_else(|| XRefStream::parse_semi_quiet::<Self>(buffer))
             .unwrap_or_else(|| {
-                Err(ParseErr::Error(
-                    IncrementRecoverable::NotFound(debug_bytes(buffer)).into(),
-                ))
+                Err(NewParseRecoverable {
+                    buffer,
+                    code: ParseErrorCode::NotFound(stringify!(Increment), None),
+                }
+                .into())
             })
     }
 }
 
 mod process {
     use super::*;
-    use crate::process::error::ProcessResult;
+    use crate::process::error::NewProcessResult;
     use crate::xref::Table;
     use crate::xref::ToTable;
 
     impl ToTable for Increment {
-        fn to_table(&self) -> ProcessResult<Table> {
+        fn to_table(&self) -> NewProcessResult<Table> {
             match self {
                 Self::Section(section) => section.to_table(),
                 Self::Stream(stream) => stream.to_table(),
@@ -87,13 +89,24 @@ mod convert {
 }
 
 pub(crate) mod error {
-
+    use ::std::num::TryFromIntError;
     use ::thiserror::Error;
 
+    use crate::process::error::NewProcessErr;
+
+    // NewProcessErr do not implement Copy
     #[derive(Debug, Error, PartialEq, Clone)]
-    pub enum IncrementRecoverable {
-        #[error("Not found: {0}")]
-        NotFound(String),
+    pub enum IncrementCode {
+        #[error("{0}. Trailer dictionary. Error: {1}")]
+        TrailerDictionary(&'static str, NewProcessErr),
+    }
+
+    #[derive(Debug, Error, PartialEq, Clone, Copy)]
+    pub enum IncrementError {
+        #[error("Generation number. Error: {1}. Input: {0}")]
+        EntryGenerationNumber(u64, TryFromIntError),
+        #[error("Duplicate object number: {0}")]
+        DuplicateObjectNumber(u64),
     }
 }
 

--- a/src/xref/increment/section/entry.rs
+++ b/src/xref/increment/section/entry.rs
@@ -1,7 +1,26 @@
+use ::nom::branch::alt;
+use ::nom::bytes::complete::tag;
+use ::nom::bytes::complete::take_while_m_n;
+use ::nom::character::complete::char;
+use ::nom::combinator::map;
+use ::nom::error::Error as NomError;
+use ::nom::sequence::pair;
+use ::nom::sequence::separated_pair;
+use ::nom::sequence::terminated;
+use ::nom::AsChar;
+use ::nom::Err as NomErr;
 use ::std::fmt::Display;
 use ::std::fmt::Formatter;
 use ::std::fmt::Result as FmtResult;
 
+use crate::new_parse_failure;
+use crate::parse::character_set::is_white_space;
+use crate::parse::error::NewParseErr;
+use crate::parse::error::NewParseFailure;
+use crate::parse::error::NewParseResult;
+use crate::parse::error::ParseErrorCode;
+use crate::parse::NewParser;
+use crate::Byte;
 use crate::GenerationNumber;
 use crate::ObjectNumberOrZero;
 use crate::Offset;
@@ -38,53 +57,97 @@ impl Display for Entry {
     }
 }
 
+impl NewParser<'_> for Entry {
+    fn parse(buffer: &[Byte]) -> NewParseResult<(&[Byte], Self)> {
+        let (buffer, entry) = terminated(
+            map(
+                separated_pair(
+                    separated_pair(
+                        take_while_m_n(BIG_LEN, BIG_LEN, AsChar::is_dec_digit),
+                        char::<_, NomError<_>>(' '),
+                        take_while_m_n(SMALL_LEN, SMALL_LEN, AsChar::is_dec_digit),
+                    ),
+                    char(' '),
+                    alt((tag(b"f"), tag(b"n"))),
+                ),
+                |value| -> NewParseResult<Entry> { Entry::try_from(value).map_err(Into::into) },
+            ),
+            pair(
+                // The below uses `many_m_n` instead of `eol` to parse exactly
+                // 20 bytes per entry.
+                take_while_m_n(1, 1, is_white_space),
+                take_while_m_n(1, 1, |byte| byte == b'\n' || byte == b'\r'),
+            ),
+        )(buffer)
+        .map_err(new_parse_failure!(
+            e,
+            NewParseFailure {
+                buffer: e.input,
+                code: ParseErrorCode::NotFound(stringify!(Entry), Some(e.code))
+            }
+        ))?;
+        Ok((buffer, entry?))
+    }
+}
+
 mod convert {
-    use self::error::EntryFailure;
+    use super::error::EntryCode;
     use super::*;
-    use crate::fmt::debug_bytes;
-    use crate::parse::error::ParseFailure;
+    use crate::parse::error::NewParseFailure;
     use crate::parse::num::ascii_to_u16;
     use crate::parse::num::ascii_to_u64;
     use crate::Byte;
 
-    impl TryFrom<((&[Byte], &[Byte]), char)> for Entry {
-        type Error = ParseFailure;
+    impl<'buffer> TryFrom<((&'buffer [Byte], &'buffer [Byte]), &'buffer [Byte])> for Entry {
+        type Error = NewParseFailure<'buffer>;
 
-        fn try_from(value: ((&[Byte], &[Byte]), char)) -> Result<Self, Self::Error> {
+        fn try_from(
+            value: ((&'buffer [Byte], &'buffer [Byte]), &'buffer [Byte]),
+        ) -> Result<Self, Self::Error> {
             let ((num_64, num_16), entry_type) = value;
             match entry_type {
-                'f' => {
-                    let next_free = ascii_to_u64(num_64)
-                        .ok_or_else(|| EntryFailure::NextFree(debug_bytes(num_64)))?;
-                    let generation_number = ascii_to_u16(num_16)
-                        .ok_or_else(|| EntryFailure::GenerationNumber(debug_bytes(num_16)))?;
+                b"f" => {
+                    let next_free = ascii_to_u64(num_64).ok_or(Self::Error {
+                        buffer: num_64,
+                        code: EntryCode::NextFree.into(),
+                    })?;
+                    let generation_number = ascii_to_u16(num_16).ok_or(Self::Error {
+                        buffer: num_16,
+                        code: EntryCode::GenerationNumber.into(),
+                    })?;
                     Ok(Self::Free(next_free, generation_number))
                 }
-                'n' => {
-                    let offset = ascii_to_u64(num_64)
-                        .ok_or_else(|| EntryFailure::OffSet(debug_bytes(num_64)))?;
-                    let generation_number = ascii_to_u16(num_16)
-                        .ok_or_else(|| EntryFailure::GenerationNumber(debug_bytes(num_16)))?;
+                b"n" => {
+                    let offset = ascii_to_u64(num_64).ok_or(Self::Error {
+                        buffer: num_64,
+                        code: ParseErrorCode::OffSet(stringify!(Entry)),
+                    })?;
+                    let generation_number = ascii_to_u16(num_16).ok_or(Self::Error {
+                        buffer: num_16,
+                        code: EntryCode::GenerationNumber.into(),
+                    })?;
                     Ok(Self::InUse(offset, generation_number))
                 }
-                _ => Err(EntryFailure::EntryType(entry_type.to_string()).into()),
+                _ => Err(Self::Error {
+                    buffer: entry_type,
+                    code: EntryCode::EntryType.into(),
+                }),
             }
         }
     }
 }
 
 pub(crate) mod error {
+
     use ::thiserror::Error;
 
-    #[derive(Debug, Error, PartialEq, Clone)]
-    pub enum EntryFailure {
-        #[error("Invalid offset. Input: {0}")]
-        OffSet(String),
-        #[error("Invalid next free object number. Input: {0}")]
-        NextFree(String),
-        #[error("Invalid generation number. Input: {0}")]
-        GenerationNumber(String),
-        #[error("Invalid entry type. Input: {0}")]
-        EntryType(String),
+    #[derive(Debug, Error, PartialEq, Clone, Copy)]
+    pub enum EntryCode {
+        #[error("Next free object number")]
+        NextFree,
+        #[error("Generation number")]
+        GenerationNumber,
+        #[error("Entry type")]
+        EntryType,
     }
 }

--- a/src/xref/increment/section/entry.rs
+++ b/src/xref/increment/section/entry.rs
@@ -2,7 +2,6 @@ use ::nom::branch::alt;
 use ::nom::bytes::complete::tag;
 use ::nom::bytes::complete::take_while_m_n;
 use ::nom::character::complete::char;
-use ::nom::combinator::map;
 use ::nom::error::Error as NomError;
 use ::nom::sequence::pair;
 use ::nom::sequence::separated_pair;
@@ -13,13 +12,13 @@ use ::std::fmt::Display;
 use ::std::fmt::Formatter;
 use ::std::fmt::Result as FmtResult;
 
-use crate::new_parse_failure;
 use crate::parse::character_set::is_white_space;
-use crate::parse::error::NewParseErr;
-use crate::parse::error::NewParseFailure;
-use crate::parse::error::NewParseResult;
+use crate::parse::error::ParseErr;
 use crate::parse::error::ParseErrorCode;
-use crate::parse::NewParser;
+use crate::parse::error::ParseFailure;
+use crate::parse::error::ParseResult;
+use crate::parse::Parser;
+use crate::parse_failure;
 use crate::Byte;
 use crate::GenerationNumber;
 use crate::ObjectNumberOrZero;
@@ -57,20 +56,17 @@ impl Display for Entry {
     }
 }
 
-impl NewParser<'_> for Entry {
-    fn parse(buffer: &[Byte]) -> NewParseResult<(&[Byte], Self)> {
+impl Parser<'_> for Entry {
+    fn parse(buffer: &[Byte]) -> ParseResult<(&[Byte], Self)> {
         let (buffer, entry) = terminated(
-            map(
+            separated_pair(
                 separated_pair(
-                    separated_pair(
-                        take_while_m_n(BIG_LEN, BIG_LEN, AsChar::is_dec_digit),
-                        char::<_, NomError<_>>(' '),
-                        take_while_m_n(SMALL_LEN, SMALL_LEN, AsChar::is_dec_digit),
-                    ),
-                    char(' '),
-                    alt((tag(b"f"), tag(b"n"))),
+                    take_while_m_n(BIG_LEN, BIG_LEN, AsChar::is_dec_digit),
+                    char::<_, NomError<_>>(' '),
+                    take_while_m_n(SMALL_LEN, SMALL_LEN, AsChar::is_dec_digit),
                 ),
-                |value| -> NewParseResult<Entry> { Entry::try_from(value).map_err(Into::into) },
+                char(' '),
+                alt((tag(b"f"), tag(b"n"))),
             ),
             pair(
                 // The below uses `many_m_n` instead of `eol` to parse exactly
@@ -79,27 +75,31 @@ impl NewParser<'_> for Entry {
                 take_while_m_n(1, 1, |byte| byte == b'\n' || byte == b'\r'),
             ),
         )(buffer)
-        .map_err(new_parse_failure!(
+        .map_err(parse_failure!(
             e,
-            NewParseFailure {
+            // Except for Subsection, Section and XRefStream, NotFound errors
+            // for xref objects should be propagated as failures.
+            ParseFailure {
                 buffer: e.input,
-                code: ParseErrorCode::NotFound(stringify!(Entry), Some(e.code))
+                object: stringify!(Entry),
+                code: ParseErrorCode::NotFound(e.code)
             }
         ))?;
-        Ok((buffer, entry?))
+        let entry = Entry::try_from(entry)?;
+        Ok((buffer, entry))
     }
 }
 
 mod convert {
-    use super::error::EntryCode;
     use super::*;
-    use crate::parse::error::NewParseFailure;
+    use crate::parse::error::ParseFailure;
     use crate::parse::num::ascii_to_u16;
     use crate::parse::num::ascii_to_u64;
+    use crate::parse::num::ascii_to_usize;
     use crate::Byte;
 
     impl<'buffer> TryFrom<((&'buffer [Byte], &'buffer [Byte]), &'buffer [Byte])> for Entry {
-        type Error = NewParseFailure<'buffer>;
+        type Error = ParseFailure<'buffer>;
 
         fn try_from(
             value: ((&'buffer [Byte], &'buffer [Byte]), &'buffer [Byte]),
@@ -109,45 +109,35 @@ mod convert {
                 b"f" => {
                     let next_free = ascii_to_u64(num_64).ok_or(Self::Error {
                         buffer: num_64,
-                        code: EntryCode::NextFree.into(),
+                        object: stringify!(Entry),
+                        code: ParseErrorCode::NextFree,
                     })?;
                     let generation_number = ascii_to_u16(num_16).ok_or(Self::Error {
                         buffer: num_16,
-                        code: EntryCode::GenerationNumber.into(),
+                        object: stringify!(Entry),
+                        code: ParseErrorCode::GenerationNumber,
                     })?;
                     Ok(Self::Free(next_free, generation_number))
                 }
                 b"n" => {
-                    let offset = ascii_to_u64(num_64).ok_or(Self::Error {
+                    let offset = ascii_to_usize(num_64).ok_or(Self::Error {
                         buffer: num_64,
-                        code: ParseErrorCode::OffSet(stringify!(Entry)),
+                        object: stringify!(Entry),
+                        code: ParseErrorCode::OffSet,
                     })?;
                     let generation_number = ascii_to_u16(num_16).ok_or(Self::Error {
                         buffer: num_16,
-                        code: EntryCode::GenerationNumber.into(),
+                        object: stringify!(Entry),
+                        code: ParseErrorCode::GenerationNumber,
                     })?;
                     Ok(Self::InUse(offset, generation_number))
                 }
                 _ => Err(Self::Error {
                     buffer: entry_type,
-                    code: EntryCode::EntryType.into(),
+                    object: stringify!(Entry),
+                    code: ParseErrorCode::EntryType,
                 }),
             }
         }
-    }
-}
-
-pub(crate) mod error {
-
-    use ::thiserror::Error;
-
-    #[derive(Debug, Error, PartialEq, Clone, Copy)]
-    pub enum EntryCode {
-        #[error("Next free object number")]
-        NextFree,
-        #[error("Generation number")]
-        GenerationNumber,
-        #[error("Entry type")]
-        EntryType,
     }
 }

--- a/src/xref/increment/section/subsection.rs
+++ b/src/xref/increment/section/subsection.rs
@@ -1,35 +1,24 @@
-use ::nom::branch::alt;
-use ::nom::bytes::complete::take_while_m_n;
 use ::nom::character::complete::char;
-use ::nom::combinator::map;
-use ::nom::error::Error as NomError;
-use ::nom::multi::many_m_n;
-use ::nom::sequence::pair;
+use ::nom::character::complete::digit1;
 use ::nom::sequence::separated_pair;
 use ::nom::sequence::terminated;
-use ::nom::AsChar;
 use ::nom::Err as NomErr;
 use ::std::fmt::Display;
 use ::std::fmt::Formatter;
 use ::std::fmt::Result as FmtResult;
-use ::std::num::ParseIntError;
+use error::SubsectionCode;
 
-use self::error::SubsectionFailure;
-use self::error::SubsectionRecoverable;
 use super::entry::Entry;
-use super::entry::BIG_LEN;
-use super::entry::SMALL_LEN;
-use crate::fmt::debug_bytes;
 use crate::parse::character_set::eol;
-use crate::parse::character_set::is_white_space;
-use crate::parse::character_set::number1;
-use crate::parse::error::ParseErr;
-use crate::parse::error::ParseFailure;
-use crate::parse::error::ParseRecoverable;
-use crate::parse::error::ParseResult;
-use crate::parse::Parser;
-use crate::parse_error;
-use crate::parse_failure;
+use crate::parse::error::NewParseFailure;
+use crate::parse::error::NewParseRecoverable;
+use crate::parse::error::NewParseResult;
+use crate::parse::error::ParseErrorCode;
+use crate::parse::num::ascii_to_u64;
+use crate::parse::num::ascii_to_usize;
+use crate::parse::NewParser;
+use crate::parse_recoverable;
+use crate::xref::increment::NewParseErr;
 use crate::Byte;
 use crate::ObjectNumberOrZero;
 
@@ -49,81 +38,56 @@ impl Display for Subsection {
     }
 }
 
-impl Parser for Subsection {
+impl NewParser<'_> for Subsection {
     // REFERENCE: [7.5.4 Cross-reference table, p56-57]
-    fn parse(buffer: &[Byte]) -> ParseResult<(&[Byte], Self)> {
-        let (buffer, (first_object_number, entry_count)) =
-            terminated(separated_pair(number1, char(' '), number1), eol)(buffer).map_err(
-                parse_error!(
+    fn parse(buffer: &[Byte]) -> NewParseResult<(&[Byte], Self)> {
+        let (mut buffer, (first_object_number, entry_count)) =
+            terminated(separated_pair(digit1, char(' '), digit1), eol)(buffer).map_err(
+                parse_recoverable!(
                     e,
-                    SubsectionRecoverable::NotFound {
-                        code: e.code,
-                        input: debug_bytes(e.input),
+                    NewParseRecoverable {
+                        buffer: e.input,
+                        code: ParseErrorCode::NotFound(stringify!(Subsection), Some(e.code))
                     }
                 ),
             )?;
         // Here, we know that the buffer starts with a cross-reference subsection, and
         // the following errors should be propagated as SubsectionFail
 
-        let first_object_number: ObjectNumberOrZero =
-            first_object_number.parse().map_err(|err: ParseIntError| {
-                ParseErr::Failure(
-                    SubsectionFailure::ObjectNumber(
-                        err.kind().clone(),
-                        first_object_number.to_string(),
-                    )
-                    .into(),
-                )
-            })?;
-        let entry_count: usize = entry_count.parse().map_err(|err: ParseIntError| {
-            ParseErr::Failure(
-                SubsectionFailure::EntryCount(err.kind().clone(), entry_count.to_string()).into(),
-            )
+        let first_object_number = ascii_to_u64(first_object_number).ok_or(NewParseFailure {
+            buffer: first_object_number,
+            code: SubsectionCode::FirstObjectNumber.into(),
+        })?;
+        let entry_count = ascii_to_usize(entry_count).ok_or(NewParseFailure {
+            buffer: entry_count,
+            code: SubsectionCode::EntryCount.into(),
         })?;
 
-        // The below uses `many_m_n` instead of `eol` to parse exactly 20 bytes
-        // per entry.
-        let (buffer, entries): (&[Byte], Vec<ParseResult<Entry>>) = many_m_n(
-            entry_count,
-            entry_count,
-            terminated(
-                map(
-                    separated_pair(
-                        separated_pair(
-                            take_while_m_n(BIG_LEN, BIG_LEN, AsChar::is_dec_digit),
-                            char::<_, NomError<_>>(' '),
-                            take_while_m_n(SMALL_LEN, SMALL_LEN, AsChar::is_dec_digit),
-                        ),
-                        char(' '),
-                        alt((char('f'), char('n'))),
-                    ),
-                    |value| -> ParseResult<Entry> { Entry::try_from(value).map_err(Into::into) },
-                ),
-                pair(
-                    take_while_m_n(1, 1, is_white_space),
-                    take_while_m_n(1, 1, |byte| byte == b'\n' || byte == b'\r'),
-                ),
-            ),
-        )(buffer)
-        .map_err(parse_failure!(
-            e,
-            SubsectionFailure::ParseEntries {
-                first_object_number,
-                entry_count,
-                code: e.code,
-                input: debug_bytes(e.input),
-            }
-        ))?;
-
-        let entries = entries.into_iter().collect::<ParseResult<Vec<_>>>()?;
-
-        Ok((
-            buffer,
-            Self {
-                first_object_number,
-                entries,
-            },
-        ))
+        (0..entry_count)
+            .try_fold(Vec::with_capacity(entry_count), |mut entries, index| {
+                let (remaining, entry) = Entry::parse(buffer).map_err(|err| NewParseFailure {
+                    buffer,
+                    code: SubsectionCode::Entry {
+                        index,
+                        first_object_number,
+                        entry_count,
+                        code: Box::new(err.code().clone()), // TODO (TEMP)
+                    }
+                    .into(),
+                })?;
+                buffer = remaining;
+                entries.push(entry);
+                Ok(entries)
+            })
+            .map(|entries| {
+                (
+                    buffer,
+                    Self {
+                        first_object_number,
+                        entries,
+                    },
+                )
+            })
     }
 }
 
@@ -145,33 +109,30 @@ mod convert {
 
 pub(crate) mod error {
 
-    use ::nom::error::ErrorKind;
-    use ::std::num::IntErrorKind;
     use ::thiserror::Error;
 
+    use crate::parse::error::ParseErrorCode;
     use crate::ObjectNumberOrZero;
 
+    // Box does not implement Copy
     #[derive(Debug, Error, PartialEq, Clone)]
-    pub enum SubsectionRecoverable {
-        #[error("Not found: {code:?}. Input: {input}")]
-        NotFound { code: ErrorKind, input: String },
-    }
-
-    #[derive(Debug, Error, PartialEq, Clone)]
-    pub enum SubsectionFailure {
-        #[error("Invalid object number: {0:?}. Input: {1}")]
-        ObjectNumber(IntErrorKind, String),
-        #[error("Invalid entry count: {0:?}. Input: {1}")]
-        EntryCount(IntErrorKind, String),
+    pub enum SubsectionCode {
+        #[error("First object number")]
+        FirstObjectNumber,
+        #[error("Entry count")]
+        EntryCount,
         #[error(
-            "Invalid entries for subsection {first_object_number} {entry_count}: {code:?}. Input: \
-             {input}"
+            "Entry number {} in subsection {} {}. Error: {}",
+            index,
+            first_object_number,
+            entry_count,
+            code
         )]
-        ParseEntries {
+        Entry {
+            index: usize,
             first_object_number: ObjectNumberOrZero,
             entry_count: usize,
-            code: ErrorKind,
-            input: String,
+            code: Box<ParseErrorCode>,
         },
     }
 }
@@ -182,14 +143,14 @@ mod tests {
 
     use super::*;
     use crate::assert_err_eq;
-    use crate::parse_assert_eq;
+    use crate::new_parse_assert_eq;
 
     #[test]
     fn subsection_valid() {
         // Synthetic test
         let buffer: &[Byte] = include_bytes!("../../../../tests/data/SYNTHETIC_subsection.bin");
         let subsection: Subsection = include!("../../../../tests/code/SYNTHETIC_subsection.rs");
-        parse_assert_eq!(buffer, subsection, "trailer\r\n".as_bytes());
+        new_parse_assert_eq!(buffer, subsection, "trailer\r\n".as_bytes());
 
         // PDF produced by Microsoft Word for Office 365
         let buffer: &[Byte] = include_bytes!(
@@ -197,7 +158,7 @@ mod tests {
         );
         let subsection: Subsection =
             include!("../../../../tests/code/B72168B54640B245A7CCF42DCDC8C026_subsection.rs");
-        parse_assert_eq!(buffer, subsection, "trailer\r\n".as_bytes());
+        new_parse_assert_eq!(buffer, subsection, "trailer\r\n".as_bytes());
     }
 
     #[test]
@@ -207,75 +168,87 @@ mod tests {
         // Subsection: Not found
         let buffer = b"0 1 R\r\n";
         let parse_result = Subsection::parse(buffer);
-        let expected_error = ParseErr::Error(
-            SubsectionRecoverable::NotFound {
-                code: ErrorKind::Tag,
-                input: "R\r\n".to_string(),
-            }
-            .into(),
-        );
+        let expected_error = NewParseRecoverable {
+            buffer: b"R\r\n",
+            code: ParseErrorCode::NotFound(stringify!(Subsection), Some(ErrorKind::Tag)),
+        };
         assert_err_eq!(parse_result, expected_error);
 
         // Subsection: Incomplete buffer
         let buffer = b"0 6\r\n0000000000 65535 f\r\n0000000100 00000 n\r\n0000000200 00000 n\r\n0000000300 00001 f\r\n0000000400 00000 n\r\n";
         let parse_result = Subsection::parse(buffer);
-        let expected_error = ParseErr::Failure(
-            SubsectionFailure::ParseEntries {
+        let expected_error = NewParseFailure {
+            buffer: b"",
+            code: SubsectionCode::Entry {
+                index: 5,
                 first_object_number: 0,
                 entry_count: 6,
-                code: ErrorKind::TakeWhileMN,
-                input: "".to_string(),
+                code: Box::new(ParseErrorCode::NotFound(
+                    stringify!(Entry),
+                    Some(ErrorKind::TakeWhileMN),
+                )),
             }
             .into(),
-        );
+        };
         assert_err_eq!(parse_result, expected_error);
 
         // Subsection: Corrupted entry: Missing eol separator
         let buffer = b"0 6\r\n0000000000 65535 f 0000000100 00000 n\r\n0000000200 00000 n\r\n0000000300 00001 f\r\n0000000400 00000 n\r\n0000000500 00000 n\r\n";
         let parse_result = Subsection::parse(buffer);
-        let expected_error = ParseErr::Failure(
-            SubsectionFailure::ParseEntries {
+        let expected_error = NewParseFailure {
+            buffer: b"0000000000 65535 f 0000000100 00000 n\r\n0000000200 00000 n\r\n0000000300 \
+                     00001 f\r\n0000000400 00000 n\r\n0000000500 00000 n\r\n",
+            code: SubsectionCode::Entry {
+                index: 0,
                 first_object_number: 0,
                 entry_count: 6,
-                code: ErrorKind::TakeWhileMN,
-                input: "0000000100 00000 n\r\n0000000200 00000 n\r\n0000000300 00001 \
-                        f\r\n0000000400 00000 n\r\n0000000500 00000 n\r\n"
-                    .to_string(),
+                code: Box::new(ParseErrorCode::NotFound(
+                    stringify!(Entry),
+                    Some(ErrorKind::TakeWhileMN),
+                )),
             }
             .into(),
-        );
+        };
         assert_err_eq!(parse_result, expected_error);
 
         // Subsection: Missing generation number
         let buffer = b"0 6\r\n0000000000 65535 f\r\n0000000100 n\r\n0000000200 00000 n\r\n0000000300 00001 f\r\n0000000400 00000 n\r\n0000000500 00000 n\r\n";
         let parse_result = Subsection::parse(buffer);
-        let expected_error = ParseErr::Failure(
-            SubsectionFailure::ParseEntries {
+        let expected_error = NewParseFailure {
+            buffer:
+                b"0000000100 n\r\n0000000200 00000 n\r\n0000000300 00001 f\r\n0000000400 00000 \
+                     n\r\n0000000500 00000 n\r\n",
+            code: SubsectionCode::Entry {
+                index: 1,
                 first_object_number: 0,
                 entry_count: 6,
-                code: ErrorKind::TakeWhileMN,
-                input: "n\r\n0000000200 00000 n\r\n0000000300 00001 f\r\n0000000400 00000 \
-                        n\r\n0000000500 00000 n\r\n"
-                    .to_string(),
+                code: Box::new(ParseErrorCode::NotFound(
+                    stringify!(Entry),
+                    Some(ErrorKind::TakeWhileMN),
+                )),
             }
             .into(),
-        );
+        };
         assert_err_eq!(parse_result, expected_error);
 
         // Subsection: Invalid entry type
         let buffer = b"0 6\r\n0000000000 65535 r\r\n0000000100 00000 n\r\n0000000200 00000 n\r\n0000000300 00001 f\r\n0000000400 00000 n\r\n0000000500 00000 n\r\n";
         let parse_result = Subsection::parse(buffer);
-        let expected_error = ParseErr::Failure(
-            SubsectionFailure::ParseEntries {
+        let expected_error = NewParseFailure {
+            buffer:
+                b"0000000000 65535 r\r\n0000000100 00000 n\r\n0000000200 00000 n\r\n0000000300 \
+                     00001 f\r\n0000000400 00000 n\r\n0000000500 00000 n\r\n",
+            code: SubsectionCode::Entry {
+                index: 0,
                 first_object_number: 0,
                 entry_count: 6,
-                code: ErrorKind::Char,
-                input: "r\r\n0000000100 00000 n\r\n0000000200 00000 n\r\n0000000300 00001 \
-                        f\r\n0000000400 00000 n\r\n0000000500 00000 n\r\n"
-                    .to_string(),
+                code: Box::new(ParseErrorCode::NotFound(
+                    stringify!(Entry),
+                    Some(ErrorKind::Tag),
+                )),
             }
             .into(),
-        );
+        };
         assert_err_eq!(parse_result, expected_error);
 
         // TODO Add tests

--- a/src/xref/increment/section/subsection.rs
+++ b/src/xref/increment/section/subsection.rs
@@ -6,19 +6,18 @@ use ::nom::Err as NomErr;
 use ::std::fmt::Display;
 use ::std::fmt::Formatter;
 use ::std::fmt::Result as FmtResult;
-use error::SubsectionCode;
 
 use super::entry::Entry;
 use crate::parse::character_set::eol;
-use crate::parse::error::NewParseFailure;
-use crate::parse::error::NewParseRecoverable;
-use crate::parse::error::NewParseResult;
+use crate::parse::error::ParseErr;
 use crate::parse::error::ParseErrorCode;
+use crate::parse::error::ParseFailure;
+use crate::parse::error::ParseRecoverable;
+use crate::parse::error::ParseResult;
 use crate::parse::num::ascii_to_u64;
 use crate::parse::num::ascii_to_usize;
-use crate::parse::NewParser;
+use crate::parse::Parser;
 use crate::parse_recoverable;
-use crate::xref::increment::NewParseErr;
 use crate::Byte;
 use crate::ObjectNumberOrZero;
 
@@ -38,44 +37,47 @@ impl Display for Subsection {
     }
 }
 
-impl NewParser<'_> for Subsection {
+impl Parser<'_> for Subsection {
     // REFERENCE: [7.5.4 Cross-reference table, p56-57]
-    fn parse(buffer: &[Byte]) -> NewParseResult<(&[Byte], Self)> {
+    fn parse(buffer: &[Byte]) -> ParseResult<(&[Byte], Self)> {
         let (mut buffer, (first_object_number, entry_count)) =
             terminated(separated_pair(digit1, char(' '), digit1), eol)(buffer).map_err(
                 parse_recoverable!(
                     e,
-                    NewParseRecoverable {
+                    ParseRecoverable {
                         buffer: e.input,
-                        code: ParseErrorCode::NotFound(stringify!(Subsection), Some(e.code))
+                        object: stringify!(Subsection),
+                        code: ParseErrorCode::NotFound(e.code)
                     }
                 ),
             )?;
         // Here, we know that the buffer starts with a cross-reference subsection, and
         // the following errors should be propagated as SubsectionFail
 
-        let first_object_number = ascii_to_u64(first_object_number).ok_or(NewParseFailure {
+        let first_object_number = ascii_to_u64(first_object_number).ok_or(ParseFailure {
             buffer: first_object_number,
-            code: SubsectionCode::FirstObjectNumber.into(),
+            object: stringify!(Subsection),
+            code: ParseErrorCode::FirstObjectNumber,
         })?;
-        let entry_count = ascii_to_usize(entry_count).ok_or(NewParseFailure {
+        let entry_count = ascii_to_usize(entry_count).ok_or(ParseFailure {
             buffer: entry_count,
-            code: SubsectionCode::EntryCount.into(),
+            object: stringify!(Subsection),
+            code: ParseErrorCode::EntryCount,
         })?;
 
         (0..entry_count)
             .try_fold(Vec::with_capacity(entry_count), |mut entries, index| {
-                let (remaining, entry) = Entry::parse(buffer).map_err(|err| NewParseFailure {
-                    buffer,
-                    code: SubsectionCode::Entry {
+                let (remains, entry) = Entry::parse(buffer).map_err(|err| ParseFailure {
+                    buffer: err.buffer(),
+                    object: stringify!(Subsection),
+                    code: ParseErrorCode::Entry {
                         index,
                         first_object_number,
                         entry_count,
-                        code: Box::new(err.code().clone()), // TODO (TEMP)
-                    }
-                    .into(),
+                        code: Box::new(err.code()),
+                    },
                 })?;
-                buffer = remaining;
+                buffer = remains;
                 entries.push(entry);
                 Ok(entries)
             })
@@ -107,50 +109,20 @@ mod convert {
     }
 }
 
-pub(crate) mod error {
-
-    use ::thiserror::Error;
-
-    use crate::parse::error::ParseErrorCode;
-    use crate::ObjectNumberOrZero;
-
-    // Box does not implement Copy
-    #[derive(Debug, Error, PartialEq, Clone)]
-    pub enum SubsectionCode {
-        #[error("First object number")]
-        FirstObjectNumber,
-        #[error("Entry count")]
-        EntryCount,
-        #[error(
-            "Entry number {} in subsection {} {}. Error: {}",
-            index,
-            first_object_number,
-            entry_count,
-            code
-        )]
-        Entry {
-            index: usize,
-            first_object_number: ObjectNumberOrZero,
-            entry_count: usize,
-            code: Box<ParseErrorCode>,
-        },
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use ::nom::error::ErrorKind;
 
     use super::*;
     use crate::assert_err_eq;
-    use crate::new_parse_assert_eq;
+    use crate::parse_assert_eq;
 
     #[test]
     fn subsection_valid() {
         // Synthetic test
         let buffer: &[Byte] = include_bytes!("../../../../tests/data/SYNTHETIC_subsection.bin");
         let subsection: Subsection = include!("../../../../tests/code/SYNTHETIC_subsection.rs");
-        new_parse_assert_eq!(buffer, subsection, "trailer\r\n".as_bytes());
+        parse_assert_eq!(buffer, subsection, "trailer\r\n".as_bytes());
 
         // PDF produced by Microsoft Word for Office 365
         let buffer: &[Byte] = include_bytes!(
@@ -158,7 +130,7 @@ mod tests {
         );
         let subsection: Subsection =
             include!("../../../../tests/code/B72168B54640B245A7CCF42DCDC8C026_subsection.rs");
-        new_parse_assert_eq!(buffer, subsection, "trailer\r\n".as_bytes());
+        parse_assert_eq!(buffer, subsection, "trailer\r\n".as_bytes());
     }
 
     #[test]
@@ -168,86 +140,105 @@ mod tests {
         // Subsection: Not found
         let buffer = b"0 1 R\r\n";
         let parse_result = Subsection::parse(buffer);
-        let expected_error = NewParseRecoverable {
+        let expected_error = ParseRecoverable {
             buffer: b"R\r\n",
-            code: ParseErrorCode::NotFound(stringify!(Subsection), Some(ErrorKind::Tag)),
+            object: stringify!(Subsection),
+            code: ParseErrorCode::NotFound(ErrorKind::Tag),
         };
         assert_err_eq!(parse_result, expected_error);
 
         // Subsection: Incomplete buffer
-        let buffer = b"0 6\r\n0000000000 65535 f\r\n0000000100 00000 n\r\n0000000200 00000 n\r\n0000000300 00001 f\r\n0000000400 00000 n\r\n";
+        let buffer = b"\
+        0 6\r\n0000000000 65535 f\r\n\
+        0000000100 00000 n\r\n\
+        0000000200 00000 n\r\n\
+        0000000300 00001 f\r\n\
+        0000000400 00000 n\r\n";
         let parse_result = Subsection::parse(buffer);
-        let expected_error = NewParseFailure {
+        let expected_error = ParseFailure {
             buffer: b"",
-            code: SubsectionCode::Entry {
+            object: stringify!(Subsection),
+            code: ParseErrorCode::Entry {
                 index: 5,
                 first_object_number: 0,
                 entry_count: 6,
-                code: Box::new(ParseErrorCode::NotFound(
-                    stringify!(Entry),
-                    Some(ErrorKind::TakeWhileMN),
-                )),
-            }
-            .into(),
+                code: Box::new(ParseErrorCode::NotFound(ErrorKind::TakeWhileMN)),
+            },
         };
         assert_err_eq!(parse_result, expected_error);
 
         // Subsection: Corrupted entry: Missing eol separator
-        let buffer = b"0 6\r\n0000000000 65535 f 0000000100 00000 n\r\n0000000200 00000 n\r\n0000000300 00001 f\r\n0000000400 00000 n\r\n0000000500 00000 n\r\n";
+        let buffer = b"0 6\r\n\
+        0000000000 65535 f 0000000100 00000 n\r\n\
+        0000000200 00000 n\r\n\
+        0000000300 00001 f\r\n\
+        0000000400 00000 n\r\n\
+        0000000500 00000 n\r\n";
         let parse_result = Subsection::parse(buffer);
-        let expected_error = NewParseFailure {
-            buffer: b"0000000000 65535 f 0000000100 00000 n\r\n0000000200 00000 n\r\n0000000300 \
-                     00001 f\r\n0000000400 00000 n\r\n0000000500 00000 n\r\n",
-            code: SubsectionCode::Entry {
+        let expected_error = ParseFailure {
+            buffer: b"0000000100 00000 n\r\n\
+                0000000200 00000 n\r\n\
+                0000000300 00001 f\r\n\
+                0000000400 00000 n\r\n\
+                0000000500 00000 n\r\n",
+            object: stringify!(Subsection),
+            code: ParseErrorCode::Entry {
                 index: 0,
                 first_object_number: 0,
                 entry_count: 6,
-                code: Box::new(ParseErrorCode::NotFound(
-                    stringify!(Entry),
-                    Some(ErrorKind::TakeWhileMN),
-                )),
-            }
-            .into(),
+                code: Box::new(ParseErrorCode::NotFound(ErrorKind::TakeWhileMN)),
+            },
         };
         assert_err_eq!(parse_result, expected_error);
 
         // Subsection: Missing generation number
-        let buffer = b"0 6\r\n0000000000 65535 f\r\n0000000100 n\r\n0000000200 00000 n\r\n0000000300 00001 f\r\n0000000400 00000 n\r\n0000000500 00000 n\r\n";
+        let buffer = b"0 6\r\n\
+        0000000000 65535 f\r\n\
+        0000000100 n\r\n\
+        0000000200 00000 n\r\n\
+        0000000300 00001 f\r\n\
+        0000000400 00000 n\r\n\
+        0000000500 00000 n\r\n";
         let parse_result = Subsection::parse(buffer);
-        let expected_error = NewParseFailure {
-            buffer:
-                b"0000000100 n\r\n0000000200 00000 n\r\n0000000300 00001 f\r\n0000000400 00000 \
-                     n\r\n0000000500 00000 n\r\n",
-            code: SubsectionCode::Entry {
+        let expected_error = ParseFailure {
+            buffer: b"n\r\n\
+            0000000200 00000 n\r\n\
+            0000000300 00001 f\r\n\
+            0000000400 00000 n\r\n\
+            0000000500 00000 n\r\n",
+            object: stringify!(Subsection),
+            code: ParseErrorCode::Entry {
                 index: 1,
                 first_object_number: 0,
                 entry_count: 6,
-                code: Box::new(ParseErrorCode::NotFound(
-                    stringify!(Entry),
-                    Some(ErrorKind::TakeWhileMN),
-                )),
-            }
-            .into(),
+                code: Box::new(ParseErrorCode::NotFound(ErrorKind::TakeWhileMN)),
+            },
         };
         assert_err_eq!(parse_result, expected_error);
 
         // Subsection: Invalid entry type
-        let buffer = b"0 6\r\n0000000000 65535 r\r\n0000000100 00000 n\r\n0000000200 00000 n\r\n0000000300 00001 f\r\n0000000400 00000 n\r\n0000000500 00000 n\r\n";
+        let buffer = b"0 6\r\n\
+        0000000000 65535 r\r\n\
+        0000000100 00000 n\r\n\
+        0000000200 00000 n\r\n\
+        0000000300 00001 f\r\n\
+        0000000400 00000 n\r\n\
+        0000000500 00000 n\r\n";
         let parse_result = Subsection::parse(buffer);
-        let expected_error = NewParseFailure {
-            buffer:
-                b"0000000000 65535 r\r\n0000000100 00000 n\r\n0000000200 00000 n\r\n0000000300 \
-                     00001 f\r\n0000000400 00000 n\r\n0000000500 00000 n\r\n",
-            code: SubsectionCode::Entry {
+        let expected_error = ParseFailure {
+            buffer: b"r\r\n\
+            0000000100 00000 n\r\n\
+            0000000200 00000 n\r\n\
+            0000000300 00001 f\r\n\
+            0000000400 00000 n\r\n\
+            0000000500 00000 n\r\n",
+            object: stringify!(Subsection),
+            code: ParseErrorCode::Entry {
                 index: 0,
                 first_object_number: 0,
                 entry_count: 6,
-                code: Box::new(ParseErrorCode::NotFound(
-                    stringify!(Entry),
-                    Some(ErrorKind::Tag),
-                )),
-            }
-            .into(),
+                code: Box::new(ParseErrorCode::NotFound(ErrorKind::Tag)),
+            },
         };
         assert_err_eq!(parse_result, expected_error);
 

--- a/src/xref/increment/stream/entry.rs
+++ b/src/xref/increment/stream/entry.rs
@@ -17,14 +17,13 @@ pub(crate) enum Entry {
 }
 
 mod convert {
-    use self::error::EntryError;
+    use super::error::EntryError;
     use super::*;
     use crate::parse::num::bytes_to_u64;
-    use crate::process::error::ProcessErr;
     use crate::Byte;
 
     impl TryFrom<(&[Byte], &[Byte], &[Byte])> for Entry {
-        type Error = ProcessErr;
+        type Error = EntryError;
         /// REFERENCE: [7.5.8.3 Cross-reference stream data, p67]
         fn try_from(value: (&[Byte], &[Byte], &[Byte])) -> Result<Self, Self::Error> {
             let (field1, field2, field3) = value;
@@ -35,30 +34,33 @@ mod convert {
             } else {
                 // REFERENCE: [7.5.8.3 Cross-reference stream data, p67]
                 // Fields are provided in the big-endian order
-                bytes_to_u64(field1).ok_or_else(|| EntryError::Overflow(field1.to_vec()))?
+                bytes_to_u64(field1).ok_or(EntryError::FieldOverflow(field1.to_vec()))?
+                // TODO (TEMP)
             };
-            let value2 =
-                bytes_to_u64(field2).ok_or_else(|| EntryError::Overflow(field2.to_vec()))?;
-            let value3 =
-                bytes_to_u64(field3).ok_or_else(|| EntryError::Overflow(field3.to_vec()))?;
+            let value2 = bytes_to_u64(field2).ok_or(EntryError::FieldOverflow(field2.to_vec()))?; // TODO (TEMP)
+            let value3 = bytes_to_u64(field3).ok_or(EntryError::FieldOverflow(field3.to_vec()))?; // TODO (TEMP)
 
             match value1 {
                 0 => {
                     let next_free = value2;
-                    let generation_number = GenerationNumber::try_from(value3)
-                        .map_err(|_| EntryError::GenerationNumber(value3))?;
+                    let generation_number = GenerationNumber::try_from(value3).map_err(|err| {
+                        EntryError::GenerationNumber(field3.to_vec(), value3, err)
+                        // TODO (TEMP)
+                    })?;
                     Ok(Self::Free(next_free, generation_number))
                 }
                 1 => {
                     let offset = value2;
-                    let generation_number = GenerationNumber::try_from(value3)
-                        .map_err(|_| EntryError::GenerationNumber(value3))?;
+                    let generation_number = GenerationNumber::try_from(value3).map_err(|err| {
+                        EntryError::GenerationNumber(field3.to_vec(), value3, err)
+                        // TODO (TEMP)
+                    })?;
                     Ok(Self::InUse(offset, generation_number))
                 }
                 2 => {
                     let object_number = ObjectNumber::try_from(value2)
-                        .map_err(|_| EntryError::ObjectNumber(value2))?;
-                    // REFERENCE: [7.5.8.3 Cross-reference stream data, p68]
+                        .map_err(|err| EntryError::ObjectNumber(field2.to_vec(), value2, err))?; // TODO (TEMP)
+                                                                                                 // REFERENCE: [7.5.8.3 Cross-reference stream data, p68]
                     let id = Id::new(object_number, GenerationNumber::default());
                     let index = value3;
                     Ok(Self::Compressed(id, index))
@@ -70,19 +72,18 @@ mod convert {
 }
 
 pub(crate) mod error {
+    use ::std::num::TryFromIntError;
     use ::thiserror::Error;
 
     use crate::Byte;
 
     #[derive(Debug, Error, PartialEq, Clone)]
     pub enum EntryError {
-        #[error("Overflow: {0:?}")]
-        Overflow(Vec<Byte>),
-        #[error("Invalid generation number. Input: {0}")]
-        GenerationNumber(u64),
-        #[error("Invalid index number. Input: {0}")]
-        ObjectNumber(u64),
-        #[error("Invalid index number. Input: {0}")]
-        IndexNumber(u64),
+        #[error("Field overflow. Input: {0:?}")]
+        FieldOverflow(Vec<Byte>),
+        #[error("Object number. Input{0:?}. Value: {1}. Error: {2}")]
+        ObjectNumber(Vec<Byte>, u64, TryFromIntError),
+        #[error("Generation number. Input{0:?}. Value: {1}. Error: {2}")]
+        GenerationNumber(Vec<Byte>, u64, TryFromIntError),
     }
 }

--- a/src/xref/increment/trailer.rs
+++ b/src/xref/increment/trailer.rs
@@ -1,10 +1,11 @@
+use ::std::collections::HashMap;
 use ::std::fmt::Display;
 use ::std::fmt::Formatter;
 use ::std::fmt::Result as FmtResult;
 
-use crate::object::direct::dictionary::Dictionary;
 use crate::object::direct::name::Name;
 use crate::object::direct::string::String_;
+use crate::object::direct::DirectValue;
 use crate::object::indirect::reference::Reference;
 use crate::IndexNumber;
 use crate::ObjectNumberOrZero;
@@ -51,7 +52,9 @@ pub(crate) struct Trailer {
     r#type: Option<Name>,
     index: Vec<(ObjectNumberOrZero, IndexNumber)>,
     w: Option<[usize; 3]>,
-    others: Dictionary,
+    // TODO(TEMP) Reconsider after finising NewProcessErr
+    // others: HashMap<&'a Name, &'a DirectValue>,
+    others: HashMap<Name, DirectValue>,
 }
 
 impl Display for Trailer {
@@ -101,8 +104,11 @@ impl Display for Trailer {
 }
 
 mod convert {
-    use super::error::TrailerFailure;
+    use ::std::collections::HashMap;
+
     use super::*;
+    use crate::object::direct::dictionary::error::DataTypeError;
+    use crate::object::direct::dictionary::error::MissingEntryError;
     use crate::object::direct::dictionary::Dictionary;
     use crate::object::direct::string::String_;
     use crate::object::direct::DirectValue;
@@ -114,66 +120,67 @@ mod convert {
     use crate::object::indirect::stream::KEY_FFILTER;
     use crate::object::indirect::stream::KEY_FILTER;
     use crate::object::indirect::stream::KEY_LENGTH;
-    use crate::parse::error::ParseFailure;
+    use crate::process::error::NewProcessErr;
     use crate::ObjectNumberOrZero;
     use crate::Offset;
 
+    // TODO(TEMP) Convert Dictionary to Dictionary<'lifetime>
     impl TryFrom<&Dictionary> for Trailer {
-        type Error = ParseFailure;
+        type Error = NewProcessErr;
 
         fn try_from(value: &Dictionary) -> Result<Self, Self::Error> {
-            let size = value
-                .get_u64(KEY_SIZE)?
-                .ok_or(TrailerFailure::MissingEntry {
-                    key: KEY_SIZE,
-                    data_type: stringify!(u64),
-                })?;
+            let size = value.get_u64(KEY_SIZE)?.ok_or(MissingEntryError {
+                key: KEY_SIZE,
+                data_type: stringify!(u64),
+            })?;
 
             let prev = value.get_u64(KEY_PREV)?;
 
-            let root = value.get_reference(KEY_ROOT)?;
+            let root = value.get_reference(KEY_ROOT)?.cloned(); // TODO (TEMP)
 
-            let encrypt = value.get_reference(KEY_ENCRYPT)?;
+            let encrypt = value.get_reference(KEY_ENCRYPT)?.cloned(); // TODO (TEMP)
 
-            let info = value.get_reference(KEY_INFO)?;
+            let info = value.get_reference(KEY_INFO)?.cloned(); // TODO (TEMP)
 
             let id = value
                 .get_array(KEY_ID)?
-                .map(|value| match value.as_slice() {
+                .map(|array| match array.as_slice() {
                     [DirectValue::String(id_1), DirectValue::String(id_2)] => {
                         // TODO Check the string lengths and report anomalies
+                        // TODO(TEMP)
                         Ok([id_1.clone(), id_2.clone()])
                     }
-                    _ => Err(TrailerFailure::WrongDataType {
+                    _ => Err(DataTypeError {
                         key: KEY_ID,
-                        data_type: stringify!([PdfString; 2]),
-                        value: value.to_string(),
+                        expected_type: stringify!([String_; 2]),
+                        value: array.to_string(),      // TODO (TEMP)
+                        dictionary: value.to_string(), // TODO (TEMP)
                     }),
                 })
                 .transpose()?;
             let xref_stm = value.get_u64(KEY_XREF_STM)?;
 
-            let r#type = value.get_name(KEY_TYPE)?;
+            let r#type = value.get_name(KEY_TYPE)?.cloned(); // TODO (TEMP)
 
             let w = value
                 .get_array(KEY_W)?
                 .map(|array| match array.as_slice() {
                     [value1, value2, value3] => {
                         let [field1, field2, field3] = [value1, value2, value3].map(|field| {
-                            field
-                                .as_usize()
-                                .ok_or_else(|| TrailerFailure::WrongDataType {
-                                    key: KEY_W,
-                                    data_type: stringify!(usize),
-                                    value: field.to_string(),
-                                })
+                            field.as_usize().ok_or(DataTypeError {
+                                key: KEY_W,
+                                expected_type: stringify!(usize),
+                                value: field.to_string(),      // TODO (TEMP)
+                                dictionary: value.to_string(), // TODO (TEMP)
+                            })
                         });
                         Ok([field1?, field2?, field3?])
                     }
-                    _ => Err(TrailerFailure::WrongValue {
+                    _ => Err(DataTypeError {
                         key: KEY_W,
-                        expected: "an array of three integers",
-                        value: array.to_string(),
+                        expected_type: stringify!(an array of three integers),
+                        value: array.to_string(),      // TODO (TEMP)
+                        dictionary: value.to_string(), // TODO (TEMP)
                     }),
                 })
                 .transpose()?;
@@ -183,29 +190,28 @@ mod convert {
                 .map(|array| {
                     let chunks = array.chunks_exact(2);
                     if !chunks.remainder().is_empty() {
-                        return Err(TrailerFailure::WrongValue {
+                        return Err(DataTypeError {
                             key: KEY_INDEX,
-                            expected: "an array of pairs of integers",
-                            value: array.to_string(),
+                            expected_type: stringify!(an array of pairs of integers),
+                            value: array.to_string(),      // TODO (TEMP)
+                            dictionary: value.to_string(), // TODO (TEMP)
                         });
                     }
                     let mut index = Vec::with_capacity(array.len() / 2);
                     for chunk in chunks {
                         if let [first_object_number, entry_count] = chunk {
                             let first_object_number =
-                                first_object_number.as_u64().ok_or_else(|| {
-                                    TrailerFailure::WrongDataType {
-                                        key: KEY_INDEX,
-                                        data_type: stringify!(ObjectNumberOrZero),
-                                        value: first_object_number.to_string(),
-                                    }
-                                })?;
-                            let entry_count = entry_count.as_u64().ok_or_else(|| {
-                                TrailerFailure::WrongDataType {
+                                first_object_number.as_u64().ok_or(DataTypeError {
                                     key: KEY_INDEX,
-                                    data_type: stringify!(IndexNumber),
-                                    value: entry_count.to_string(),
-                                }
+                                    expected_type: stringify!(ObjectNumberOrZero),
+                                    value: array.to_string(), // TODO (TEMP)
+                                    dictionary: value.to_string(), // TODO (TEMP)
+                                })?;
+                            let entry_count = entry_count.as_u64().ok_or(DataTypeError {
+                                key: KEY_INDEX,
+                                expected_type: stringify!(IndexNumber),
+                                value: array.to_string(),      // TODO (TEMP)
+                                dictionary: value.to_string(), // TODO (TEMP)
                             })?;
                             index.push((first_object_number, entry_count));
                         } else {
@@ -219,21 +225,21 @@ mod convert {
                 .transpose()?
                 .unwrap_or_default();
 
-            let others: Dictionary = value
-                .iter()
+            let others: HashMap<_, _> = value
+                .clone() // TODO(TEMP))
+                .into_iter() // TODO(TEMP)
                 .filter(|(key, _)| {
-                    key != &KEY_SIZE
-                        && key != &KEY_PREV
-                        && key != &KEY_ROOT
-                        && key != &KEY_ENCRYPT
-                        && key != &KEY_INFO
-                        && key != &KEY_ID
-                        && key != &KEY_XREF_STM
-                        && key != &KEY_TYPE
-                        && key != &KEY_INDEX
-                        && key != &KEY_W
+                    key.ne(KEY_SIZE)
+                        && key.ne(KEY_PREV)
+                        && key.ne(KEY_ROOT)
+                        && key.ne(KEY_ENCRYPT)
+                        && key.ne(KEY_INFO)
+                        && key.ne(KEY_ID)
+                        && key.ne(KEY_XREF_STM)
+                        && key.ne(KEY_TYPE)
+                        && key.ne(KEY_INDEX)
+                        && key.ne(KEY_W)
                 })
-                .map(|(key, value)| (key.clone(), value.clone()))
                 .collect();
 
             // Report non-expected additional/missing entries in the trailer dictionar
@@ -243,13 +249,13 @@ mod convert {
             for (key, value) in others.iter() {
                 // REFERENCE: [Table 5 — Entries common to all stream
                 // dictionaries, p32-33]
-                if key != KEY_LENGTH
-                    && key != KEY_FILTER
-                    && key != KEY_DECODEPARMS
-                    && key != KEY_F
-                    && key != KEY_FFILTER
-                    && key != KEY_FDECODEPARMS
-                    && key != KEY_DL
+                if key.ne(KEY_LENGTH)
+                    && key.ne(KEY_FILTER)
+                    && key.ne(KEY_DECODEPARMS)
+                    && key.ne(KEY_F)
+                    && key.ne(KEY_FFILTER)
+                    && key.ne(KEY_FDECODEPARMS)
+                    && key.ne(KEY_DL)
                 {
                     eprintln!("Trailer contains additional entry: {} {}", key, value);
                 }
@@ -338,7 +344,7 @@ mod convert {
             self
         }
 
-        pub(crate) fn set_others(mut self, others: Dictionary) -> Self {
+        pub(crate) fn set_others(mut self, others: HashMap<Name, DirectValue>) -> Self {
             self.others = others;
             self
         }
@@ -383,43 +389,19 @@ mod convert {
             self.w.as_ref()
         }
 
-        pub(crate) fn others(&self) -> &Dictionary {
+        pub(crate) fn others(&self) -> &HashMap<Name, DirectValue> {
             &self.others
         }
-    }
-}
-
-pub(crate) mod error {
-    use ::thiserror::Error;
-
-    #[derive(Debug, Error, PartialEq, Clone)]
-    pub enum TrailerFailure {
-        #[error("Wrong value. Key {key}. Expected a {expected} value, found {value}")]
-        WrongValue {
-            key: &'static str,
-            expected: &'static str,
-            value: String,
-        },
-        #[error("Wrong data type. Key {key}. Expected a {data_type} value, found {value}")]
-        WrongDataType {
-            key: &'static str,
-            data_type: &'static str,
-            value: String,
-        },
-        #[error("Missing required key {key}. Expected a {data_type} value")]
-        MissingEntry {
-            key: &'static str,
-            data_type: &'static str,
-        },
     }
 }
 
 #[cfg(test)]
 mod tests {
 
-    use super::error::TrailerFailure;
     use super::*;
     use crate::assert_err_eq;
+    use crate::object::direct::dictionary::error::MissingEntryError;
+    use crate::object::direct::dictionary::Dictionary;
     use crate::object::direct::string::Hexadecimal;
     use crate::object::direct::string::Literal;
     use crate::object::indirect::object::IndirectObject;
@@ -474,7 +456,7 @@ mod tests {
                 Hexadecimal::from("1F0F80D27D156F7EF35B1DF40B1BD3E8").into(),
             ])
             .set_type(Name::from(VAL_XREF))
-            .set_others(Dictionary::from_iter([
+            .set_others(HashMap::from_iter([
                 (Name::from(KEY_LENGTH), 1760.into()),
                 (Name::from(KEY_FILTER), Name::from("FlateDecode").into()),
             ]));
@@ -491,9 +473,9 @@ mod tests {
         let buffer = b"<</Root 2 0 R /Info 1 0 R>>\nstartxref\n99999\n%%EOF";
         let (_, dictionary) = Dictionary::parse(buffer).unwrap();
         let parse_result = Trailer::try_from(&dictionary);
-        let expected_error = TrailerFailure::MissingEntry {
-            key: "Size",
-            data_type: "u64",
+        let expected_error = MissingEntryError {
+            key: KEY_SIZE,
+            data_type: stringify!(u64),
         };
         assert_err_eq!(parse_result, expected_error);
 
@@ -503,10 +485,10 @@ mod tests {
         // let (_, dictionary) = Dictionary::parse(buffer).unwrap();
         // let parse_result = Trailer::try_from(&dictionary);
         // let expected_error = DataTypeErr {
-        //     key: KEY_SIZE.to_string(),
+        //     key: KEY_SIZE,
         //     expected_type: stringify!(u64),
-        //     value: "1.1".to_string(),
-        //     dictionary: "<</Size 1.1/Root 2 0 R/Info 1 0 R>>".to_string(),
+        //     value: "1.1",
+        //     dictionary: "<</Size 1.1/Root 2 0 R/Info 1 0 R>>",
         // };
         // assert_err_eq!(parse_result, expected_error);
 

--- a/src/xref/increment/trailer.rs
+++ b/src/xref/increment/trailer.rs
@@ -134,33 +134,33 @@ mod convert {
                 data_type: stringify!(u64),
             })?;
 
-            let prev = value.get_u64(KEY_PREV)?;
+            let prev = value.get_usize(KEY_PREV)?;
 
-            let root = value.get_reference(KEY_ROOT)?.cloned(); // TODO (TEMP)
+            let root = value.get_reference(KEY_ROOT)?.cloned(); // TODO (TEMP) Remove cloned
 
-            let encrypt = value.get_reference(KEY_ENCRYPT)?.cloned(); // TODO (TEMP)
+            let encrypt = value.get_reference(KEY_ENCRYPT)?.cloned(); // TODO (TEMP) Remove cloned
 
-            let info = value.get_reference(KEY_INFO)?.cloned(); // TODO (TEMP)
+            let info = value.get_reference(KEY_INFO)?.cloned(); // TODO (TEMP) Remove cloned
 
             let id = value
                 .get_array(KEY_ID)?
                 .map(|array| match array.as_slice() {
                     [DirectValue::String(id_1), DirectValue::String(id_2)] => {
                         // TODO Check the string lengths and report anomalies
-                        // TODO(TEMP)
+                        // TODO(TEMP) Remove clone
                         Ok([id_1.clone(), id_2.clone()])
                     }
                     _ => Err(DataTypeError {
-                        key: KEY_ID,
+                        entry: KEY_ID,
                         expected_type: stringify!([String_; 2]),
-                        value: array.to_string(),      // TODO (TEMP)
-                        dictionary: value.to_string(), // TODO (TEMP)
+                        value: array.to_string(), // TODO (TEMP) Remove to_string()
+                        object: value.to_string(), // TODO (TEMP) Remove to_string()
                     }),
                 })
                 .transpose()?;
-            let xref_stm = value.get_u64(KEY_XREF_STM)?;
+            let xref_stm = value.get_usize(KEY_XREF_STM)?;
 
-            let r#type = value.get_name(KEY_TYPE)?.cloned(); // TODO (TEMP)
+            let r#type = value.get_name(KEY_TYPE)?.cloned(); // TODO (TEMP) Remove cloned
 
             let w = value
                 .get_array(KEY_W)?
@@ -168,19 +168,19 @@ mod convert {
                     [value1, value2, value3] => {
                         let [field1, field2, field3] = [value1, value2, value3].map(|field| {
                             field.as_usize().ok_or(DataTypeError {
-                                key: KEY_W,
+                                entry: KEY_W,
                                 expected_type: stringify!(usize),
-                                value: field.to_string(),      // TODO (TEMP)
-                                dictionary: value.to_string(), // TODO (TEMP)
+                                value: field.to_string(), // TODO (TEMP) Remove to_string()
+                                object: value.to_string(), // TODO (TEMP) Remove to_string()
                             })
                         });
                         Ok([field1?, field2?, field3?])
                     }
                     _ => Err(DataTypeError {
-                        key: KEY_W,
+                        entry: KEY_W,
                         expected_type: stringify!(an array of three integers),
-                        value: array.to_string(),      // TODO (TEMP)
-                        dictionary: value.to_string(), // TODO (TEMP)
+                        value: array.to_string(), // TODO (TEMP) Remove to_string()
+                        object: value.to_string(), // TODO (TEMP) Remove to_string()
                     }),
                 })
                 .transpose()?;
@@ -191,10 +191,10 @@ mod convert {
                     let chunks = array.chunks_exact(2);
                     if !chunks.remainder().is_empty() {
                         return Err(DataTypeError {
-                            key: KEY_INDEX,
+                            entry: KEY_INDEX,
                             expected_type: stringify!(an array of pairs of integers),
-                            value: array.to_string(),      // TODO (TEMP)
-                            dictionary: value.to_string(), // TODO (TEMP)
+                            value: array.to_string(), // TODO (TEMP) Remove to_string()
+                            object: value.to_string(), // TODO (TEMP) Remove to_string()
                         });
                     }
                     let mut index = Vec::with_capacity(array.len() / 2);
@@ -202,16 +202,16 @@ mod convert {
                         if let [first_object_number, entry_count] = chunk {
                             let first_object_number =
                                 first_object_number.as_u64().ok_or(DataTypeError {
-                                    key: KEY_INDEX,
+                                    entry: KEY_INDEX,
                                     expected_type: stringify!(ObjectNumberOrZero),
-                                    value: array.to_string(), // TODO (TEMP)
-                                    dictionary: value.to_string(), // TODO (TEMP)
+                                    value: array.to_string(), // TODO (TEMP) Remove to_string()
+                                    object: value.to_string(), // TODO (TEMP) Remove to_string()
                                 })?;
                             let entry_count = entry_count.as_u64().ok_or(DataTypeError {
-                                key: KEY_INDEX,
+                                entry: KEY_INDEX,
                                 expected_type: stringify!(IndexNumber),
-                                value: array.to_string(),      // TODO (TEMP)
-                                dictionary: value.to_string(), // TODO (TEMP)
+                                value: array.to_string(), // TODO (TEMP) Remove to_string()
+                                object: value.to_string(), // TODO (TEMP) Remove to_string()
                             })?;
                             index.push((first_object_number, entry_count));
                         } else {
@@ -226,8 +226,8 @@ mod convert {
                 .unwrap_or_default();
 
             let others: HashMap<_, _> = value
-                .clone() // TODO(TEMP))
-                .into_iter() // TODO(TEMP)
+                .clone() // TODO(TEMP)) Remove clone
+                .into_iter() // TODO(TEMP) Use iter() instead
                 .filter(|(key, _)| {
                     key.ne(KEY_SIZE)
                         && key.ne(KEY_PREV)

--- a/src/xref/mod.rs
+++ b/src/xref/mod.rs
@@ -4,8 +4,8 @@ pub(crate) mod startxref;
 
 use ::std::collections::BTreeSet;
 use ::std::collections::HashMap;
-use error::XRefError;
 
+use self::error::XRefError;
 use crate::object::indirect::id::Id;
 use crate::process::error::NewProcessResult;
 use crate::GenerationNumber;
@@ -52,7 +52,7 @@ impl Table {
         generation_number: GenerationNumber,
         offset: Offset,
     ) -> Result<(), XRefError> {
-        // TODO 'static
+        // TODO use 'static if a lifetime is introduced
         let object_number = ObjectNumber::new(object_number).ok_or(XRefError::XRefInUseObject {
             object_number,
             generation_number,
@@ -70,7 +70,7 @@ impl Table {
         stream_id: Id,
         index: IndexNumber,
     ) -> Result<Option<(Id, IndexNumber)>, XRefError> {
-        // TODO 'static
+        // TODO use 'static if a lifetime is introduced
         let object_number =
             ObjectNumber::new(object_number).ok_or(XRefError::XRefCompressedObject {
                 object_number,
@@ -137,7 +137,7 @@ mod tests {
     use ::std::path::PathBuf;
 
     use super::pretable::PreTable;
-    use crate::parse::NewParser;
+    use crate::parse::Parser;
     use crate::xref::ToTable;
 
     #[test]

--- a/src/xref/mod.rs
+++ b/src/xref/mod.rs
@@ -4,10 +4,10 @@ pub(crate) mod startxref;
 
 use ::std::collections::BTreeSet;
 use ::std::collections::HashMap;
+use error::XRefError;
 
-use self::error::TableError;
 use crate::object::indirect::id::Id;
-use crate::process::error::ProcessResult;
+use crate::process::error::NewProcessResult;
 use crate::GenerationNumber;
 use crate::IndexNumber;
 use crate::ObjectNumber;
@@ -15,7 +15,8 @@ use crate::ObjectNumberOrZero;
 use crate::Offset;
 
 pub(crate) trait ToTable {
-    fn to_table(&self) -> ProcessResult<Table>;
+    // TODO(TEMP) Consider consuming the object
+    fn to_table(&self) -> NewProcessResult<Table>;
 }
 
 #[derive(Debug, PartialEq, Default)]
@@ -50,8 +51,9 @@ impl Table {
         object_number: ObjectNumberOrZero,
         generation_number: GenerationNumber,
         offset: Offset,
-    ) -> ProcessResult<()> {
-        let object_number = ObjectNumber::new(object_number).ok_or(TableError::ObjectNumber {
+    ) -> Result<(), XRefError> {
+        // TODO 'static
+        let object_number = ObjectNumber::new(object_number).ok_or(XRefError::XRefInUseObject {
             object_number,
             generation_number,
             offset,
@@ -67,12 +69,14 @@ impl Table {
         object_number: ObjectNumberOrZero,
         stream_id: Id,
         index: IndexNumber,
-    ) -> ProcessResult<Option<(Id, IndexNumber)>> {
-        let object_number = ObjectNumber::new(object_number).ok_or(TableError::ObjectNumber {
-            object_number,
-            generation_number: GenerationNumber::default(),
-            offset: Offset::default(),
-        })?;
+    ) -> Result<Option<(Id, IndexNumber)>, XRefError> {
+        // TODO 'static
+        let object_number =
+            ObjectNumber::new(object_number).ok_or(XRefError::XRefCompressedObject {
+                object_number,
+                stream_id,
+                index,
+            })?;
         let id = Id::new(object_number, GenerationNumber::default());
         Ok(self.compressed.insert(id, (stream_id, index)))
     }
@@ -90,28 +94,42 @@ impl Table {
 pub(crate) mod error {
     use ::thiserror::Error;
 
-    use super::*;
+    use crate::object::indirect::id::Id;
+    use crate::GenerationNumber;
+    use crate::IndexNumber;
+    use crate::ObjectNumberOrZero;
+    use crate::Offset;
 
-    #[derive(Debug, Error, PartialEq, Clone)]
-    pub enum TableError {
+    #[derive(Debug, Error, PartialEq, Clone, Copy)]
+    pub enum XRefError {
         #[error(
-            "Object number: {object_number}, Generation number: {generation_number}, Offset: \
-             {offset}"
+            "In-use Object. Number: {}, Generation: {}, Offset: {}",
+            object_number,
+            generation_number,
+            offset
         )]
-        ObjectNumber {
+        XRefInUseObject {
             object_number: ObjectNumberOrZero,
             generation_number: GenerationNumber,
             offset: Offset,
         },
-        #[error("Duplicate object number: {0}")]
-        DuplicateObjectNumber(u64),
+        #[error(
+            "Compressed Object. Number: {}, Stream: {}, index: {}",
+            object_number,
+            stream_id,
+            index
+        )]
+        XRefCompressedObject {
+            object_number: ObjectNumberOrZero,
+            stream_id: Id,
+            index: IndexNumber,
+        },
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::collections::VecDeque;
-
+    use ::std::collections::VecDeque;
     use ::std::fs::read_dir;
     use ::std::fs::File;
     use ::std::io::BufReader;
@@ -119,8 +137,8 @@ mod tests {
     use ::std::path::PathBuf;
 
     use super::pretable::PreTable;
-    use super::*;
-    use crate::parse::Parser;
+    use crate::parse::NewParser;
+    use crate::xref::ToTable;
 
     #[test]
     fn xref_valid() {
@@ -158,7 +176,7 @@ mod tests {
                             }
                             Err(err) => {
                                 eprintln!("{}: Error: {}", path.display(), err);
-                                err_msgs.push(path.display().to_string());
+                                err_msgs.push(path);
                             }
                         }
                     }
@@ -206,7 +224,7 @@ mod tests {
                         match pretable {
                             Ok((_, pretable)) if pretable.to_table().is_ok() => {
                                 eprintln!("{}: # Increments {:?}", path.display(), pretable.len());
-                                err_msgs.push(path.display().to_string());
+                                err_msgs.push(path);
                             }
                             Ok(_) => {
                                 println!(

--- a/tests/code/8401FBC530C8AE9B8EC1425170A70921_trailer.rs
+++ b/tests/code/8401FBC530C8AE9B8EC1425170A70921_trailer.rs
@@ -6,7 +6,7 @@ unsafe {
         Hexadecimal::from("8401FBC530C8AE9B8EC1425170A70921").into(),
         Hexadecimal::from("8401FBC530C8AE9B8EC1425170A70921").into(),
     ])
-    .set_others(Dictionary::from_iter([
+    .set_others(HashMap::from_iter([
         (
             "rgid".into(),
             Literal::from("PB:318039020_AS:510882528206848@1498815294792").into(),


### PR DESCRIPTION
The use of cloned buffers in parse errors significantly impacted their performance. 

The <code>Parser::parse</code> method returns two types of errors:
-	<code>ParseErr::Recoverable</code>, signifying that the parser is unable to determine the object type and the buffer needs to be reprocessed using an alternative parser.
-	<code>ParseErr::Failure</code>, signifying that the parser is able to determine the object type but fails to parse it successfully.

For several types, the implementation of <code>Parser::parse</code> employs backtracking, trying alternative parsers when encountering a recoverable error. Parsers' performance was particularly impacted in these cases, as it resulted in multiple copies of the same buffer for the sole reason of providing an error message, which the caller function often suppressed.

This PR replaces cloned buffers in parser errors with references, addressing the above issue. It also standardises parser error messages using the <code>ParseErrorCode</code> enum.