### PR TITLE
Add support for length references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,8 @@ jobs:
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: ${{ runner.os }}-cargo-
 
+    - name: Build
+      run: cargo build --tests --release
+
     - name: Run tests
       run: cargo test --release

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,18 @@ repos:
   #   hooks:
   #     - id: yamlfmt
 # ------------------------------------------------------------
-# Rust Testing
+# Rust Build
+# ------------------------------------------------------------
+  - repo: local
+    hooks:
+      - id: cargo-build
+        name: cargo build
+        entry: cargo build --tests --release
+        language: system
+        pass_filenames: false
+        always_run: true
+# ------------------------------------------------------------
+# Rust Test
 # ------------------------------------------------------------
   - repo: local
     hooks:
@@ -39,7 +50,7 @@ repos:
         pass_filenames: false
         always_run: true
 # ------------------------------------------------------------
-# FIXME Rust Testing
+# FIXME Rust Format
 # ------------------------------------------------------------
 # - repo: local
 #   hooks:

--- a/TODO.md
+++ b/TODO.md
@@ -12,8 +12,6 @@
 
 ## Features
 
-- Recursively look up indirect reference values.
-- Read stream length from an indirect reference.
 - Parse free and compressed objects.
 - Log comments in their context.
 - Report unparsed spans in the PDF file.

--- a/src/object/direct/mod.rs
+++ b/src/object/direct/mod.rs
@@ -94,19 +94,22 @@ impl<'buffer> ObjectParser<'buffer> for DirectValue<'buffer> {
     }
 }
 
-mod lookup {
-    use ::std::collections::HashMap;
-
+mod resolve {
     use super::*;
+    use crate::object::error::ObjectErrorCode;
+    use crate::parse::ParsedObjects;
 
     impl DirectValue<'_> {
-        pub(crate) fn lookup<'a>(
-            &self,
-            _parsed_objects: &'a HashMap<Reference, DirectValue>,
-        ) -> Option<&'a DirectValue> {
-            todo!("Implement lookup and report unfound references")
-            // REFERENCE: [7.3.9 Null object, p33]
-            // TODO Indirect references to non-existent objects should resolve to null
+        // TODO Cache the result of the resolve method or store it inplace
+        pub(crate) fn resolve<'buffer>(
+            &'buffer self,
+            parsed_objects: &'buffer ParsedObjects,
+        ) -> Result<&DirectValue, ObjectErrorCode> {
+            if let DirectValue::Reference(reference) = self {
+                reference.resolve(parsed_objects)
+            } else {
+                Ok(self)
+            }
         }
     }
 }

--- a/src/object/error.rs
+++ b/src/object/error.rs
@@ -4,6 +4,8 @@ use crate::error::DisplayUsingBuffer;
 use crate::fmt::debug_bytes;
 use crate::parse::Span;
 use crate::Byte;
+use crate::GenerationNumber;
+use crate::ObjectNumber;
 
 pub(crate) type ObjectResult<T> = Result<T, ObjectErr>;
 
@@ -38,6 +40,12 @@ pub enum ObjectErrorCode {
         expected_type: &'static str,
         value_span: Span,
     },
+    #[error("Cyclic reference: {0} {1}")]
+    CyclicReference(ObjectNumber, GenerationNumber),
+    #[error("Missing referenced object: {0} {1}")]
+    MissingReferencedObject(ObjectNumber, GenerationNumber),
+    #[error("Reference resolves to a stream: {0} {1}")]
+    ReferenceToStream(ObjectNumber, GenerationNumber),
     #[error("Missing required entry")]
     MissingRequiredEntry,
 }

--- a/src/object/indirect/reference.rs
+++ b/src/object/indirect/reference.rs
@@ -65,6 +65,75 @@ impl ObjectParser<'_> for Reference {
     }
 }
 
+mod resolve {
+    use ::std::collections::HashSet;
+
+    use super::*;
+    use crate::object::direct::DirectValue;
+    use crate::object::error::ObjectErrorCode;
+    use crate::object::indirect::IndirectValue;
+    use crate::parse::ParsedObjects;
+    use crate::GenerationNumber;
+    use crate::ObjectNumber;
+
+    impl Reference {
+        // TODO Cache the result of the resolve method or store it inplace
+        pub(crate) fn resolve<'buffer>(
+            &'buffer self,
+            parsed_objects: &'buffer ParsedObjects,
+        ) -> Result<&DirectValue, ObjectErrorCode> {
+            let mut seen = HashSet::<(ObjectNumber, GenerationNumber)>::default();
+            let mut object_number = self.id.object_number;
+            let mut generation_number = self.id.generation_number;
+            loop {
+                // Check for cyclic references. Break the loop if the object has
+                // already been resolved.
+                if !seen.insert((object_number, generation_number)) {
+                    // TODO Replace with a warning/ValidationError
+                    eprintln!(
+                        "WARNING: Cyclic reference detected. The cycle involves the following \
+                         objects:",
+                    );
+                    for (object_number, generation_number) in seen {
+                        eprintln!("{} {}", object_number, generation_number);
+                    }
+                    return Err(ObjectErrorCode::CyclicReference(
+                        self.id.object_number,
+                        self.id.generation_number,
+                    ));
+                }
+                let value = parsed_objects
+                    .get(&(object_number, generation_number))
+                    .map(|object| &object.value);
+                match value {
+                    Some(IndirectValue::Stream(_)) => {
+                        return Err(ObjectErrorCode::ReferenceToStream(
+                            self.id.object_number,
+                            self.id.generation_number,
+                        ))
+                    }
+                    Some(IndirectValue::Direct(DirectValue::Reference(reference))) => {
+                        object_number = reference.id.object_number;
+                        generation_number = reference.id.generation_number;
+                    }
+                    Some(IndirectValue::Direct(value)) => return Ok(value),
+                    None => {
+                        // REFERENCE: [7.3.9 Null object, p33]
+                        // Indirect references to non-existent objects should
+                        // resolve to null. This method returns None instead of
+                        // Some(Null) as Null initialisation requires specifying
+                        // its span.
+                        return Err(ObjectErrorCode::MissingReferencedObject(
+                            self.id.object_number,
+                            self.id.generation_number,
+                        ));
+                    }
+                }
+            }
+        }
+    }
+}
+
 mod convert {
     use ::std::ops::Deref;
 

--- a/src/process/filter/flate.rs
+++ b/src/process/filter/flate.rs
@@ -89,7 +89,8 @@ mod tests {
     use crate::assert_err_eq;
     use crate::lax_stream_defilter_filter;
     use crate::object::indirect::stream::Stream;
-    use crate::parse::ObjectParser;
+    use crate::parse::ResolvingParser;
+    use crate::parse::ParsedObjects;
     use crate::process::filter::error::FilterErr;
 
     #[test]

--- a/src/process/filter/lzw.rs
+++ b/src/process/filter/lzw.rs
@@ -332,7 +332,7 @@ mod convert {
             if let Some(decode_parms) = decode_parms {
                 let predictor = Predictor::new(decode_parms)?;
                 let early_change = decode_parms
-                    .opt_get(KEY_EARLY_CHANGE)
+                    .get(KEY_EARLY_CHANGE)
                     .map(EarlyChange::try_from)
                     .transpose()?
                     .unwrap_or_default();
@@ -427,7 +427,8 @@ mod tests {
     use super::*;
     use crate::assert_err_eq;
     use crate::object::indirect::stream::Stream;
-    use crate::parse::ObjectParser;
+    use crate::parse::ResolvingParser;
+    use crate::parse::ParsedObjects;
     // use crate::lax_stream_defilter_filter;
     use crate::strict_stream_defilter_filter;
 

--- a/src/process/filter/mod.rs
+++ b/src/process/filter/mod.rs
@@ -195,15 +195,15 @@ mod convert {
         pub(crate) fn new(dictionary: &Dictionary) -> FilterResult<Self> {
             // TODO Move this to a separate function that `parses` the stream
             // dictionary according to a specific schema.
-            let filtering = if dictionary.opt_get(KEY_F).is_some() {
-                dictionary.opt_get(KEY_FFILTER)
+            let filtering = if dictionary.get(KEY_F).is_some() {
+                dictionary.get(KEY_FFILTER)
             } else {
-                dictionary.opt_get(KEY_FILTER)
+                dictionary.get(KEY_FILTER)
             };
-            let decode_pars = if dictionary.opt_get(KEY_F).is_some() {
-                dictionary.opt_get(KEY_FDECODEPARMS)
+            let decode_pars = if dictionary.get(KEY_F).is_some() {
+                dictionary.get(KEY_FDECODEPARMS)
             } else {
-                dictionary.opt_get(KEY_DECODEPARMS)
+                dictionary.get(KEY_DECODEPARMS)
             };
 
             let filter_chain = match (filtering, decode_pars) {
@@ -282,7 +282,7 @@ mod tests {
     #[macro_export]
     macro_rules! strict_stream_defilter_filter {
         ($buffer:expr, $expected:expr) => {
-            let stream = Stream::parse($buffer, 0).unwrap();
+            let stream = Stream::parse($buffer, 0, &ParsedObjects::default()).unwrap();
             let defiltered = stream.defilter().unwrap();
             assert_eq!(defiltered, $expected);
             let refiltered = stream.filter_buffer(defiltered.as_slice()).unwrap();
@@ -299,7 +299,7 @@ mod tests {
     #[macro_export]
     macro_rules! lax_stream_defilter_filter {
         ($buffer:expr, $expected:expr) => {
-            let stream = Stream::parse($buffer, 0).unwrap();
+            let stream = Stream::parse($buffer, 0, &ParsedObjects::default()).unwrap();
             let defiltered = stream.defilter().unwrap();
             assert_eq!(defiltered, $expected);
             let refiltered = stream.filter_buffer(defiltered.as_slice()).unwrap();

--- a/src/process/filter/predictor/mod.rs
+++ b/src/process/filter/predictor/mod.rs
@@ -74,17 +74,17 @@ mod convert {
     impl Predictor {
         pub(in crate::process::filter) fn new(decode_parms: &Dictionary) -> FilterResult<Self> {
             let bits_per_component = decode_parms
-                .opt_get(KEY_BITS_PER_COMPONENT)
+                .get(KEY_BITS_PER_COMPONENT)
                 .map(BitsPerComponent::try_from)
                 .transpose()?
                 .unwrap_or_default();
             let colors = decode_parms
-                .opt_get(KEY_COLORS)
+                .get(KEY_COLORS)
                 .map(Colors::try_from)
                 .transpose()?
                 .unwrap_or_default();
             let columns = decode_parms
-                .opt_get(KEY_COLUMNS)
+                .get(KEY_COLUMNS)
                 .map(Columns::try_from)
                 .transpose()?
                 .unwrap_or_default();
@@ -94,7 +94,7 @@ mod convert {
                 columns,
             };
 
-            match decode_parms.opt_get(KEY_PREDICTOR) {
+            match decode_parms.get(KEY_PREDICTOR) {
                 Some(DirectValue::Numeric(Numeric::Integer(value))) => match value.deref() {
                     1 => Ok(Self::None),
                     2 => Ok(Self::Tiff(Tiff::new(parms))),

--- a/src/process/filter/predictor/png.rs
+++ b/src/process/filter/predictor/png.rs
@@ -19,7 +19,7 @@ impl<'buffer> Filter<'buffer> for Png {
     fn filter(
         &self,
         bytes: impl Into<Vec<Byte>> + AsRef<[Byte]> + 'buffer,
-    ) -> FilterResult< Vec<Byte>> {
+    ) -> FilterResult<Vec<Byte>> {
         let bytes = bytes.as_ref();
         // REFERENCE:
         // [[https://www.w3.org/TR/png/#4Concepts.EncodingScanlineAbs]
@@ -74,7 +74,7 @@ impl<'buffer> Filter<'buffer> for Png {
     fn defilter(
         &self,
         bytes: impl Into<Vec<Byte>> + AsRef<[Byte]> + 'buffer,
-    ) -> FilterResult< Vec<Byte>> {
+    ) -> FilterResult<Vec<Byte>> {
         let bytes = bytes.as_ref();
 
         let bits_per_scanline =
@@ -435,7 +435,8 @@ mod tests {
 
     use crate::lax_stream_defilter_filter;
     use crate::object::indirect::stream::Stream;
-    use crate::parse::ObjectParser;
+    use crate::parse::ResolvingParser;
+    use crate::parse::ParsedObjects;
 
     #[test]
     fn png_valid() {

--- a/src/xref/increment/mod.rs
+++ b/src/xref/increment/mod.rs
@@ -32,7 +32,7 @@ impl Display for Increment<'_> {
 }
 
 impl<'buffer> ObjectParser<'buffer> for Increment<'buffer> {
-    fn parse(buffer: &'buffer [Byte], offset: crate::Offset) -> ParseResult<'buffer, Self> {
+    fn parse(buffer: &'buffer [Byte], offset: crate::Offset) -> ParseResult<Self> {
         Section::parse_suppress_recoverable::<Self>(buffer, offset)
             .or_else(|| XRefStream::parse_suppress_recoverable::<Self>(buffer, offset))
             .unwrap_or_else(|| {

--- a/src/xref/increment/trailer.rs
+++ b/src/xref/increment/trailer.rs
@@ -414,6 +414,8 @@ mod tests {
     use crate::object::indirect::stream::KEY_LENGTH;
     use crate::object::indirect::IndirectValue;
     use crate::parse::ObjectParser;
+    use crate::parse::ResolvingParser;
+    use crate::parse::ParsedObjects;
 
     #[test]
     fn section_trailer_valid() {
@@ -465,7 +467,7 @@ mod tests {
         // PDF produced by pdfTeX-1.40.22
         let buffer =
             include_bytes!("../../../tests/data/1F0F80D27D156F7EF35B1DF40B1BD3E8_xref_stream.bin");
-        let object = IndirectObject::parse(buffer, 0).unwrap();
+        let object = IndirectObject::parse(buffer, 0, &ParsedObjects::default()).unwrap();
         let val_ref = Name::new(VAL_XREF, Span::new(19, 5));
         let key_length = KEY_LENGTH.to_vec();
 


### PR DESCRIPTION
- Introduced the <code>Reference::resolve</code> and <code>DirectValue::resolve</code> methods to recursively resolve references to their direct values.
- Added the trait <code>ResolvingParser</code>, which takes into account the already parsed objects and uses the resolved length value.
- Implemented the <code>ResolvingParser</code> trait for <code>IndirectObject</code>, <code>ÌndirectValue</code> and <code>Stream</code>.
- Amended the <code>PdfBuilder::parse_objects_in_use</code> method to loop and try to parse objects until the set of parsed objects stabilises.